### PR TITLE
Que no se resalte lo que no se puede tocar

### DIFF
--- a/src/components/buttons/TrayIconBattery.vue
+++ b/src/components/buttons/TrayIconBattery.vue
@@ -2,11 +2,11 @@
 /** biome-ignore-all lint/correctness/noUnusedImports: <Use in template> */
 /** biome-ignore-all lint/correctness/noUnusedVariables: <Use in template> */
 import { useI18n } from '@vasakgroup/tauri-plugin-i18n';
-import { useSymbol } from '@/tools/composables/useReactiveIcon';
 import { computed, onMounted, ref } from 'vue';
 import TrayIconButton from '@/components/buttons/TrayIconButton.vue';
 import type { BatteryInfo } from '@/interfaces/battery';
 import { getBatteryInfo } from '@/services/core.service';
+import { useSymbol } from '@/tools/composables/useReactiveIcon';
 import { useSharedEvent } from '@/tools/event.bus';
 import { logError } from '@/utils/logger';
 
@@ -86,10 +86,6 @@ async function getBatteryInfoComp() {
 	}
 }
 
-async function toggleBatteryInfo() {
-	// Toggle behavior for battery info display
-}
-
 onMounted(async () => {
 	await getBatteryInfoComp();
 });
@@ -111,7 +107,7 @@ useSharedEvent<BatteryInfo>('battery-update', (payload) => {
       'opacity-60': !batteryInfo.has_battery,
       'animate-pulse': batteryInfo.is_charging,
     }"
-    @click="toggleBatteryInfo"
+    :interactive="false"
   />
 </template>
 

--- a/src/components/buttons/TrayIconButton.vue
+++ b/src/components/buttons/TrayIconButton.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    class="theme-transition p-1 rounded-corner relative hover:bg-primary group transition-all duration-300"
-    :class="customClass"
+    class="theme-transition p-1 rounded-corner relative group transition-all duration-300"
+    :class="[customClass, interactive ? 'cursor-pointer hover:bg-primary' : '']"
     :title="tooltip"
     @click="handleClick"
     @mouseenter="showTooltip = true"
@@ -56,6 +56,14 @@ interface Props {
 	tooltipClass?: string | Record<string, boolean>;
 	showCustomTooltip?: boolean;
 	customTooltipText?: string;
+	/**
+	 * Si hacer clic hace algo.
+	 *
+	 * Los que sólo informan —la batería, Bloq Mayús, el micrófono silenciado—
+	 * se pintaban al pasar el mouse como si fueran botones: el resaltado promete
+	 * un clic que no existe. Con esto quedan quietos.
+	 */
+	interactive?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
@@ -67,6 +75,7 @@ withDefaults(defineProps<Props>(), {
 	tooltipClass: '',
 	showCustomTooltip: false,
 	customTooltipText: '',
+	interactive: true,
 });
 
 const emit = defineEmits<{

--- a/src/components/buttons/TrayIconCapsLock.vue
+++ b/src/components/buttons/TrayIconCapsLock.vue
@@ -3,8 +3,8 @@
 /** biome-ignore-all lint/correctness/noUnusedVariables: <Use in template> */
 import { useI18n } from '@vasakgroup/tauri-plugin-i18n';
 import { ref } from 'vue';
-import { useSymbol } from '@/tools/composables/useReactiveIcon';
 import TrayIconButton from '@/components/buttons/TrayIconButton.vue';
+import { useSymbol } from '@/tools/composables/useReactiveIcon';
 import { useEventListener } from '@/tools/event.listener';
 
 const { t } = useI18n();
@@ -24,5 +24,6 @@ useEventListener<{ active: boolean }>('caps-lock-changed', (event) => {
     :icon="capsLockIcon"
     :tooltip="t('components.TrayIconCapsLock.capsLock')"
     :alt="t('components.TrayIconCapsLock.capsLock')"
+    :interactive="false"
   />
 </template>

--- a/src/components/buttons/TrayIconMicrophone.vue
+++ b/src/components/buttons/TrayIconMicrophone.vue
@@ -3,8 +3,8 @@
 /** biome-ignore-all lint/correctness/noUnusedVariables: <Use in template> */
 import { useI18n } from '@vasakgroup/tauri-plugin-i18n';
 import { ref } from 'vue';
-import { useSymbol } from '@/tools/composables/useReactiveIcon';
 import TrayIconButton from '@/components/buttons/TrayIconButton.vue';
+import { useSymbol } from '@/tools/composables/useReactiveIcon';
 import { useEventListener } from '@/tools/event.listener';
 
 const { t } = useI18n();
@@ -24,5 +24,6 @@ useEventListener<{ active: boolean }>('mic-mute-changed', (event) => {
     :icon="micIcon"
     :tooltip="t('components.TrayIconMicrophone.muted')"
     :alt="t('components.TrayIconMicrophone.muted')"
+    :interactive="false"
   />
 </template>


### PR DESCRIPTION
La batería tenía un clic que iba a una función vacía, y el resaltado al pasar el mouse prometía algo que no pasaba. Lo mismo con Bloq Mayús y el micrófono silenciado: informan, no son botones.

El botón de la bandeja ahora sabe si tiene acción, y sólo en ese caso se pinta y muestra la manito. Los que sí hacen algo —red, sonido, Bluetooth, Twingate— no cambian.