### PR TITLE
El reproductor: el título arriba y los controles abajo

### DIFF
--- a/src/components/widgets/MusicWidget.vue
+++ b/src/components/widgets/MusicWidget.vue
@@ -113,80 +113,85 @@ watch(
 
 <template>
   <!--
-    Tres columnas: portada, texto y controles. Los controles eran el pie de la
-    columna del texto, y ahí quedaban alineados a la izquierda debajo del
-    título: en un widget ancho la fila de botones aparecía perdida en una
-    esquina. Como columna propia quedan centrados y a la misma distancia del
-    borde en cualquier forma que tenga el widget.
+    Dos filas: arriba qué está sonando, abajo los controles ocupando todo el
+    ancho. Antes eran tres columnas y los botones quedaban apretados contra el
+    borde derecho, con la mitad del ancho desperdiciado entre el título y ellos.
 
-    Las medidas van en unidades de contenedor —cqmin, el lado más chico— así
-    que todo acompaña el tamaño de la celda en los dos ejes. El marco (fondo,
-    blur, borde) no está acá: lo pone el contenedor de widgets, igual para todos.
+    Las medidas van en unidades de contenedor —cqmin, el lado más chico— así que
+    todo acompaña el tamaño de la celda en los dos ejes. El marco (fondo, blur,
+    borde) no está acá: lo pone el contenedor de widgets, igual para todos.
   -->
-  <div class="relative flex h-full w-full items-center gap-[3cqmin] p-[4cqmin]">
-    <img
-      :src="imgSrc"
-      :alt="musicInfo.title"
-      :title="musicInfo.title"
-      class="aspect-square w-[min(30cqw,80cqh)] shrink-0 rounded-corner object-cover"
-      :class="{ 'animate-pulse': isPlaying }"
-      @error="onImgError"
-    />
+  <div class="relative flex h-full w-full flex-col gap-[2cqmin] p-[3cqmin]">
+    <!-- Arriba: la portada y el título. `min-h-0` para que esta fila pueda
+         encogerse y los controles nunca queden fuera del widget. -->
+    <div class="flex min-h-0 flex-1 items-center gap-[3cqmin]">
+      <img
+        :src="imgSrc"
+        :alt="musicInfo.title"
+        :title="musicInfo.title"
+        class="aspect-square h-full max-h-full shrink-0 rounded-corner object-cover"
+        :class="{ 'animate-pulse': isPlaying }"
+        @error="onImgError"
+      />
 
-    <div class="flex min-w-0 flex-1 flex-col justify-center">
-      <div ref="titleContainer" class="overflow-hidden" :title="musicInfo.title || ''">
-        <span
-          ref="titleInner"
-          class="inline-block whitespace-nowrap text-[clamp(0.72rem,14cqmin,1rem)] font-medium text-tx-main"
-          :class="{ marquee: titleOverflow }"
-          :style="
-            titleOverflow
-              ? {
-                  '--marquee-distance': `${marqueeDistance}px`,
-                  '--marquee-duration': `${marqueeDuration}s`,
-                }
-              : {}
-          "
+      <div class="flex min-w-0 flex-1 flex-col justify-center">
+        <div ref="titleContainer" class="overflow-hidden" :title="musicInfo.title || ''">
+          <span
+            ref="titleInner"
+            class="inline-block whitespace-nowrap text-[clamp(0.72rem,13cqmin,1.05rem)] font-medium text-tx-main"
+            :class="{ marquee: titleOverflow }"
+            :style="
+              titleOverflow
+                ? {
+                    '--marquee-distance': `${marqueeDistance}px`,
+                    '--marquee-duration': `${marqueeDuration}s`,
+                  }
+                : {}
+            "
+          >
+            {{ musicInfo.title || t('components.MusicWidget.unknownTitle') }}
+          </span>
+        </div>
+
+        <div
+          class="truncate text-[clamp(0.65rem,10cqmin,0.9rem)] text-tx-muted"
+          :title="musicInfo.artist || ''"
         >
-          {{ musicInfo.title || t('components.MusicWidget.unknownTitle') }}
-        </span>
-      </div>
-
-      <div
-        class="truncate text-[clamp(0.65rem,11cqmin,0.85rem)] text-tx-muted"
-        :title="musicInfo.artist || ''"
-      >
-        {{ musicInfo.artist || "" }}
+          {{ musicInfo.artist || "" }}
+        </div>
       </div>
     </div>
 
-    <div class="flex shrink-0 items-center justify-center gap-[2cqmin]">
+    <!-- Abajo: los controles, repartidos en partes iguales. Con `flex-1` cada
+         botón ocupa lo mismo y la fila llega a los dos bordes, en vez de
+         quedar amontonada en una esquina. -->
+    <div class="flex shrink-0 items-stretch gap-[2cqmin]">
       <button
-        class="flex aspect-square w-[clamp(1.5rem,24cqmin,2.75rem)] shrink-0 items-center justify-center rounded-corner bg-ui-surface/60"
+        class="flex h-[clamp(1.25rem,20cqmin,2.5rem)] flex-1 items-center justify-center rounded-corner bg-ui-surface/60 transition-colors hover:bg-ui-surface"
         :title="t('components.MusicWidget.previous')"
         @click.prevent="onPrev"
       >
-        <img :src="prevIcon" :alt="t('components.MusicWidget.previous')" class="w-[50%]" />
+        <img :src="prevIcon" :alt="t('components.MusicWidget.previous')" class="h-[55%] w-auto" />
       </button>
 
       <button
-        class="flex aspect-square w-[clamp(1.75rem,28cqmin,3.25rem)] shrink-0 items-center justify-center rounded-corner bg-primary/80"
+        class="flex h-[clamp(1.25rem,20cqmin,2.5rem)] flex-[1.4] items-center justify-center rounded-corner bg-primary/80 transition-colors hover:bg-primary"
         :title="isPlaying ? t('components.MusicWidget.pause') : t('components.MusicWidget.play')"
         @click.prevent="onPlayPause"
       >
         <img
           :src="isPlaying ? pauseIcon : playIcon"
           :alt="isPlaying ? t('components.MusicWidget.pause') : t('components.MusicWidget.play')"
-          class="w-[50%]"
+          class="h-[60%] w-auto"
         />
       </button>
 
       <button
-        class="flex aspect-square w-[clamp(1.5rem,24cqmin,2.75rem)] shrink-0 items-center justify-center rounded-corner bg-ui-surface/60"
+        class="flex h-[clamp(1.25rem,20cqmin,2.5rem)] flex-1 items-center justify-center rounded-corner bg-ui-surface/60 transition-colors hover:bg-ui-surface"
         :title="t('components.MusicWidget.next')"
         @click.prevent="onNext"
       >
-        <img :src="nextIcon" :alt="t('components.MusicWidget.next')" class="w-[50%]" />
+        <img :src="nextIcon" :alt="t('components.MusicWidget.next')" class="h-[55%] w-auto" />
       </button>
     </div>
 


### PR DESCRIPTION
Eran tres columnas —portada, texto, botones— y los botones quedaban apretados contra el borde derecho, con la mitad del ancho desperdiciado entre el título y ellos. Ahora son dos filas: arriba qué está sonando, abajo los tres controles repartidos en partes iguales de borde a borde, con el de reproducir un poco más grande porque es el que se busca.

La fila de arriba puede encogerse (`min-h-0`), así que los controles nunca quedan fuera del widget por más chica que sea la celda.