### PR TITLE
El hueco del menú acepta cualquier widget del escritorio

### DIFF
--- a/src/components/widgets/WidgetSlot.vue
+++ b/src/components/widgets/WidgetSlot.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import DesktopClockWidget from '@/components/widgets/DesktopClockWidget.vue';
+import FilesWidget from '@/components/widgets/FilesWidget.vue';
+import MusicWidget from '@/components/widgets/MusicWidget.vue';
+import WeatherWidget from '@/components/widgets/WeatherWidget.vue';
+import { WIDGETS, type WidgetType } from '@/tools/widgets/catalog';
+
+/**
+ * Un widget del escritorio, fuera de la cuadrícula.
+ *
+ * Los widgets miden todo en unidades de contenedor —`cqmin`, el lado más chico—
+ * y quien declara ese contenedor es el marco de la cuadrícula. Puesto en
+ * cualquier otro lado, esas medidas se resuelven contra la ventana entera: el
+ * clima en el menú se dibujaba con el tamaño equivocado, que es exactamente lo
+ * que pasó.
+ *
+ * Esto es ese marco, sin la parte de arrastrar y redimensionar. Cualquier widget
+ * puesto acá se adapta al hueco que le toque, y cambiar cuál se muestra es
+ * cambiar una palabra.
+ */
+const props = withDefaults(
+	defineProps<{
+		type?: WidgetType;
+		/** Algunos se muestran de más de una forma; el clima, por ejemplo. */
+		variant?: string;
+	}>(),
+	{ type: 'weather', variant: undefined }
+);
+
+const componentes = {
+	clock: DesktopClockWidget,
+	music: MusicWidget,
+	weather: WeatherWidget,
+	files: FilesWidget,
+} as const;
+
+const componente = computed(() => componentes[props.type]);
+
+/** La forma por omisión del widget, si quien lo pone no eligió una. */
+const variante = computed(() => props.variant ?? WIDGETS[props.type].variants?.[0]?.id);
+</script>
+
+<template>
+	<!-- El mismo marco que en el escritorio: fondo, blur, borde y esquinas, y el
+	     contenedor contra el que se miden las unidades de adentro. -->
+	<div
+		style="container-type: size"
+		class="h-full w-full overflow-hidden rounded-corner border border-ui-border bg-ui-bg/80 backdrop-blur-md"
+	>
+		<component :is="componente" :variant="variante" />
+	</div>
+</template>

--- a/src/views/MenuView.vue
+++ b/src/views/MenuView.vue
@@ -12,7 +12,7 @@ import CategoryMenuPill from '@/components/buttons/CategoryMenuPill.vue';
 import SessionButton from '@/components/buttons/SessionButton.vue';
 import UserMenuCard from '@/components/cards/UserMenuCard.vue';
 import SearchMenuComponent from '@/components/SearchMenuComponent.vue';
-import WeatherWidget from '@/components/widgets/WeatherWidget.vue';
+import WidgetSlot from '@/components/widgets/WidgetSlot.vue';
 import { getMenuItems, openApp } from '@/services/app.service';
 import { openSettings, toggleSessionPopup } from '@/services/window.service';
 import { useIcons } from '@/tools/composables/useReactiveIcon';
@@ -131,20 +131,24 @@ onMounted(() => {
 	});
 	document.addEventListener('keydown', onKeydown);
 	window.addEventListener('blur', onBlur);
-	menuWindow.onFocusChanged(({ payload: focused }) => {
-		if (focused) {
-			// Shown again after being hidden: the animation state has to be
-			// reset or the menu comes back mid-fade and never becomes solid.
-			leaving.value = false;
-			setTimeout(() => document.getElementById('search')?.focus(), 50);
-			return;
-		}
-		// Losing focus was never handled — only gaining it — so clicking
-		// somewhere else left the menu open over whatever you clicked. The DOM
-		// `blur` event does not stand in for this: the webview keeps its own
-		// focus when another window takes the compositor's.
-		closeAfterAnimation();
-	}).then(fn => { unlistenFocus = fn; });
+	menuWindow
+		.onFocusChanged(({ payload: focused }) => {
+			if (focused) {
+				// Shown again after being hidden: the animation state has to be
+				// reset or the menu comes back mid-fade and never becomes solid.
+				leaving.value = false;
+				setTimeout(() => document.getElementById('search')?.focus(), 50);
+				return;
+			}
+			// Losing focus was never handled — only gaining it — so clicking
+			// somewhere else left the menu open over whatever you clicked. The DOM
+			// `blur` event does not stand in for this: the webview keeps its own
+			// focus when another window takes the compositor's.
+			closeAfterAnimation();
+		})
+		.then((fn) => {
+			unlistenFocus = fn;
+		});
 });
 
 onBeforeUnmount(() => {
@@ -281,8 +285,12 @@ const onBlur = () => {
             </div>
           </div>
 
-          <div class="rounded-corner bg-ui-bg/80 border border-ui-border p-4 overflow-y-auto min-h-0">
-            <WeatherWidget />
+          <!-- El hueco de la derecha acepta cualquiera de los widgets del
+               escritorio: cambiar `type` alcanza. El marco y el contenedor los
+               pone WidgetSlot, que es lo que hace que las medidas de adentro se
+               resuelvan contra este hueco y no contra la ventana entera. -->
+          <div class="min-h-0">
+            <WidgetSlot type="weather" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
El clima del menú se dibujaba con el tamaño equivocado desde que los widgets miden todo en unidades de contenedor: quien declara ese contenedor es el marco de la cuadrícula, y en el menú no había ninguno, así que las medidas se resolvían contra la ventana entera.

Ahora ese hueco usa el mismo marco —fondo, blur, borde y el contenedor— sin la parte de arrastrar y redimensionar, que ahí no tiene sentido. Cambiar qué widget se muestra es cambiar una palabra, y el que se ponga se adapta solo al hueco.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable widget container that supports selecting widget types and variants.
  * Added consistent full-size layout, sizing context, and desktop-style framing for widgets.
  * Updated the menu view to display the weather widget through the new container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->