### PR TITLE
Al desconectar un monitor la pantalla quedaba negra

### DIFF
--- a/src-tauri/src/monitor_manager.rs
+++ b/src-tauri/src/monitor_manager.rs
@@ -1,7 +1,7 @@
 use gdk::prelude::*;
 use std::cell::Cell;
 use std::time::Duration;
-use tauri::{AppHandle, Monitor};
+use tauri::{AppHandle, Manager, Monitor};
 
 use crate::logger::{log_debug, log_error, log_info};
 use crate::windows_apps::desktop::create_desktops;
@@ -108,15 +108,61 @@ pub fn find_gdk_monitor(monitor: &Monitor) -> Option<gdk::Monitor> {
 }
 
 /// Rebuilds every panel and desktop for the monitors currently connected.
+/// Los prefijos de las superficies que se rehacen al cambiar los monitores.
+const SUPERFICIES: [&str; 2] = ["panel", "desktop"];
+
+/// Cada cuánto se vuelve a mirar si las etiquetas quedaron libres.
+const ESPERA_ENTRE_INTENTOS: Duration = Duration::from_millis(120);
+
+/// Cuántas veces: medio segundo en total, de sobra para lo que tarda el cierre
+/// de una ventana y poco como para no dejar la pantalla vacía si algo falló.
+const INTENTOS: u32 = 4;
+
 pub fn rebuild_shell_surfaces(app: &AppHandle) {
     log_info("Reconstruyendo paneles y escritorios por cambio de monitores");
 
-    destroy_layer_windows(app, &["panel", "desktop"]);
+    destroy_layer_windows(app, &SUPERFICIES);
+    recrear_cuando_se_liberen(app.clone(), 0);
+}
 
-    if let Err(error) = create_desktops(app) {
+/// Qué etiquetas siguen ocupadas.
+///
+/// Cerrar una ventana no libera su etiqueta en el mismo instante: la baja la
+/// procesa el bucle de eventos. Recrear antes de eso falla con «a webview with
+/// label `panel` already exists», y ahí no queda ni panel ni escritorio: la
+/// pantalla se ve negra hasta reiniciar la sesión. Es exactamente lo que pasaba
+/// al desconectar un monitor.
+fn ocupadas<'a>(etiquetas: impl Iterator<Item = &'a str>, prefijos: &[&str]) -> Vec<String> {
+    etiquetas
+        .filter(|etiqueta| prefijos.iter().any(|prefijo| etiqueta.starts_with(prefijo)))
+        .map(str::to_string)
+        .collect()
+}
+
+fn recrear_cuando_se_liberen(app: AppHandle, intento: u32) {
+    let ventanas = app.webview_windows();
+    let pendientes = ocupadas(ventanas.keys().map(String::as_str), &SUPERFICIES);
+
+    if !pendientes.is_empty() {
+        if intento < INTENTOS {
+            gtk::glib::timeout_add_local_once(ESPERA_ENTRE_INTENTOS, move || {
+                recrear_cuando_se_liberen(app, intento + 1);
+            });
+            return;
+        }
+
+        // Se intenta igual: una etiqueta trabada deja esa superficie afuera,
+        // pero las demás pueden crearse y algo es mejor que una pantalla negra.
+        log_error(&format!(
+            "Estas ventanas no terminaron de cerrarse: {}. Se recrea igual.",
+            pendientes.join(", ")
+        ));
+    }
+
+    if let Err(error) = create_desktops(&app) {
         log_error(&format!("No se pudieron recrear los escritorios: {}", error));
     }
-    if let Err(error) = create_panels(app) {
+    if let Err(error) = create_panels(&app) {
         log_error(&format!("No se pudieron recrear los paneles: {}", error));
     }
 }
@@ -169,4 +215,46 @@ pub fn watch_monitor_changes(app: &AppHandle) {
     }
 
     log_info("Vigilancia de cambios de monitores activa");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cerrar una ventana no libera su etiqueta en el acto, y recrearla antes
+    /// falla con «already exists»: sin panel ni escritorio, la pantalla queda
+    /// negra. Esto es lo que decide si conviene esperar un poco más.
+    #[test]
+    fn una_etiqueta_del_shell_todavia_ocupada_se_reconoce() {
+        let etiquetas = ["panel", "menu", "control_center"];
+
+        assert_eq!(
+            ocupadas(etiquetas.into_iter(), &SUPERFICIES),
+            vec!["panel".to_string()]
+        );
+    }
+
+    #[test]
+    fn los_escritorios_de_los_otros_monitores_cuentan() {
+        // En un monitor secundario la etiqueta lleva el índice, y esa ventana
+        // también hay que esperar a que se cierre.
+        let etiquetas = ["desktop", "desktop_1", "desktop_2"];
+
+        assert_eq!(ocupadas(etiquetas.into_iter(), &SUPERFICIES).len(), 3);
+    }
+
+    #[test]
+    fn las_ventanas_que_no_son_del_shell_no_frenan_nada() {
+        // El menú, el centro de control o un applet abierto no tienen nada que
+        // ver con rehacer las superficies: esperarlos sería esperar para
+        // siempre.
+        let etiquetas = ["menu", "applet_network", "systray_popup", "vsk_context_menu"];
+
+        assert!(ocupadas(etiquetas.into_iter(), &SUPERFICIES).is_empty());
+    }
+
+    #[test]
+    fn sin_ventanas_no_hay_nada_que_esperar() {
+        assert!(ocupadas(std::iter::empty(), &SUPERFICIES).is_empty());
+    }
 }

--- a/src-tauri/src/windows_apps/desktop.rs
+++ b/src-tauri/src/windows_apps/desktop.rs
@@ -1,6 +1,7 @@
 use gtk_layer_shell::Layer;
 use tauri::AppHandle;
 
+use crate::logger::log_error;
 use crate::monitor_manager::{find_gdk_monitor, get_monitors, get_primary_monitor, label_for};
 use crate::windows_apps::shell_layer::{spawn_layer_window, LayerSpec};
 
@@ -9,12 +10,25 @@ pub fn create_desktops(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>
     let monitors = get_monitors(app).ok_or("No monitors found")?;
     let primary = get_primary_monitor(app).ok_or("No primary monitor found")?;
 
+    let mut creados = 0;
+
     for (index, monitor) in monitors.iter().enumerate() {
         let label = label_for("desktop", monitor, &primary, index);
 
         if let Err(error) = setup_desktop(app, &label, monitor) {
-            log::error!("Desktop {} failed: {}", label, error);
+            // Con el logger propio y no con `log::error!`: el crate `log` no
+            // tiene backend en esta aplicación, así que ese mensaje no llegaba
+            // a ningún lado. Un escritorio que no se crea es una pantalla negra,
+            // y quedaba sin rastro.
+            log_error(&format!("No se pudo crear el escritorio {label}: {error}"));
+            continue;
         }
+
+        creados += 1;
+    }
+
+    if creados == 0 {
+        return Err("no se pudo crear ningún escritorio".into());
     }
 
     Ok(())

--- a/src-tauri/src/windows_apps/shell_layer.rs
+++ b/src-tauri/src/windows_apps/shell_layer.rs
@@ -221,10 +221,17 @@ pub fn destroy_layer_windows(app: &AppHandle, prefixes: &[&str]) {
         }
     });
 
-    // The hidden xdg-toplevels still exist behind each layer window.
+    // Detrás de cada superficie de capa queda su ventana de Tauri.
+    //
+    // `close()` **pide** el cierre: emite el evento y la baja la procesa el
+    // bucle más tarde, así que la etiqueta sigue ocupada al volver de acá y
+    // recrearla falla. `destroy()` la cierra sin preguntar, que es lo que
+    // corresponde cuando la estamos rehaciendo nosotros.
     for (label, window) in app.webview_windows() {
         if matches(&label) {
-            let _ = window.close();
+            if let Err(error) = window.destroy() {
+                log::error!("No se pudo cerrar {label}: {error}");
+            }
         }
     }
 }

--- a/src-tauri/src/windows_apps/shell_layer.rs
+++ b/src-tauri/src/windows_apps/shell_layer.rs
@@ -4,6 +4,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 
+use crate::logger::log_error;
+
 // Layer-shell windows owned by the shell, keyed by window label.
 //
 // These used to be handed to `std::mem::forget` so GTK would keep them alive.
@@ -230,7 +232,11 @@ pub fn destroy_layer_windows(app: &AppHandle, prefixes: &[&str]) {
     for (label, window) in app.webview_windows() {
         if matches(&label) {
             if let Err(error) = window.destroy() {
-                log::error!("No se pudo cerrar {label}: {error}");
+                // Con el logger propio, por lo mismo que en `desktop.rs`: el
+                // crate `log` no tiene backend en esta aplicación, así que un
+                // `log::error!` acá se descarta. Justo el silencio que este
+                // arreglo vino a sacar.
+                log_error(&format!("No se pudo cerrar {label}: {error}"));
             }
         }
     }


### PR DESCRIPTION
Rehacer las superficies del escritorio empezaba por cerrar las que había, y `close()` no cierra: **pide** el cierre, y la baja la procesa el bucle de eventos más tarde. Al volver de esa llamada la etiqueta seguía ocupada, así que crear la nueva fallaba con «a webview with label `panel` already exists» y no quedaba ni panel ni escritorio. Medido en el registro de la sesión, al pasar de dos monitores a uno:

    17:34:29 Reconstruyendo paneles y escritorios por cambio de monitores
    17:34:29 ERROR No se pudieron recrear los paneles: a webview with label
             `panel` already exists

Del escritorio no hay ni esa línea, y ahí está la segunda mitad del problema: su fallo se registraba con `log::error!`, y el crate `log` no tiene backend en esta aplicación. La pantalla se quedaba negra sin dejar rastro de por qué.

Tres cambios:

* Se cierra con `destroy()`, que cierra de verdad en vez de pedirlo.
* Antes de recrear se comprueba que las etiquetas estén libres, y si no se espera —hasta medio segundo, en cuatro intentos—. Pasado eso se recrea igual: una superficie trabada es mejor que ninguna.
* El fallo de un escritorio va al registro de la aplicación, y si no se pudo crear ninguno eso ahora es un error y no un silencio.

Los cuatro tests nuevos cubren qué ventanas hay que esperar: las del panel y las de los escritorios de cada monitor, y ninguna otra —esperar al menú o a un applet abierto sería esperar para siempre—.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when rebuilding desktop and panel surfaces by waiting for previous windows to fully release.
  * Added clearer error reporting when shell windows cannot be destroyed or desktop setup fails.
  * Desktop setup now continues across available monitors and reports an error only if no desktops can be created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->