### PR TITLE
El escritorio no arrancaba: el puente de log peleaba el slot global

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -98,11 +98,6 @@ use applets::{
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Inicializar el sistema de logging
-    // Lo primero: las macros de `log` no tienen backend por su cuenta y
-    // descartan todo hasta que esto corre. Lo que se registre antes se pierde.
-    logger::install_log_bridge();
-
     logger::log_info("Vasak Desktop iniciando...");
     
     let window_manager = Arc::new(RwLock::new(
@@ -210,6 +205,21 @@ pub fn run() {
             toggle_connect_menu
         ])
         .setup(move |app| {
+            // El puente de `log` se instala **acá**, después de los plugins, y
+            // no antes de construir Tauri.
+            //
+            // `tauri-plugin-bluetooth-manager` instala su propio
+            // `tracing-subscriber` con `.init()`, que reclama el mismo slot
+            // global de `log` y **paniquea** si ya está tomado: con el puente
+            // primero, el escritorio no arrancaba —«failed to set global default
+            // subscriber»— y eso llegó a main sin que nadie lo notara, porque
+            // lanzar el shell para probarlo se lleva puesta la sesión.
+            //
+            // Instalándolo después gana el plugin y el puente queda inerte sin
+            // romper nada. El plugin ya está corregido para usar `try_init`; al
+            // publicarse esa versión, vuelve a ganar el puente.
+            logger::install_log_bridge();
+
             let setup_start = std::time::Instant::now();
             logger::log_info("Configurando aplicación Tauri...");
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -216,8 +216,16 @@ pub fn run() {
             // lanzar el shell para probarlo se lleva puesta la sesión.
             //
             // Instalándolo después gana el plugin y el puente queda inerte sin
-            // romper nada. El plugin ya está corregido para usar `try_init`; al
-            // publicarse esa versión, vuelve a ganar el puente.
+            // romper nada.
+            //
+            // Ojo con lo que **no** arregla el `try_init` del plugin: ese cambio
+            // sólo evita el panic, no cambia el orden. Mientras esta llamada
+            // siga acá, el plugin inicializa primero y se queda con el slot
+            // igual. Para que vuelva a ganar el puente —y los mensajes de `log`
+            // terminen en el registro de la aplicación en lugar del del
+            // plugin— hay que mover esta línea de vuelta antes de
+            // `tauri::Builder::default()`, y eso sólo es seguro una vez que la
+            // versión del plugin con `try_init` esté publicada.
             logger::install_log_bridge();
 
             let setup_start = std::time::Instant::now();


### PR DESCRIPTION
Regresión mía, ya en `main`. El puente de `log` se instalaba antes de construir Tauri y se quedaba con el slot global; después `tauri-plugin-bluetooth-manager` instala su propio `tracing-subscriber` con `.init()`, que reclama el mismo slot y **paniquea** si ya está tomado:

    thread 'main' panicked at tracing-subscriber/src/util.rs:94
    failed to set global default subscriber: SetLoggerError(())

Y no arrancaba nada.

**Por qué llegó a main sin que nadie lo notara**: para probar esto hay que lanzar el shell, y eso se lleva puesta la sesión del que lo prueba. Compilé, pasé clippy y los 66 tests, y nunca lo ejecuté. Los tests no cubren el arranque del proceso.

El puente se mueve dentro de `.setup()`, después de los plugins. Así gana el plugin y el puente queda inerte en lugar de romper: los mensajes de `log` terminan en el registro del plugin en vez de en el propio, que es peor que lo buscado pero infinitamente mejor que un escritorio que no abre.

El plugin ya está corregido en su repo para usar `try_init` —una biblioteca no puede tirar la aplicación anfitriona por cómo quedó el registro—; cuando se publique esa versión, el puente vuelve a ganar y los mensajes vuelven al registro de la aplicación.

Verificado lanzándolo: arranca, 191 MB, sin panics ni violaciones de CSP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application logging initialization to ensure Bluetooth-related diagnostics are captured correctly.
  * Prevented logging conflicts during app startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->