### PR TITLE
perf: el escritorio escucha el disco en vez de releerlo cada diez seg…

### DIFF
--- a/src-tauri/src/desktop_watcher.rs
+++ b/src-tauri/src/desktop_watcher.rs
@@ -1,0 +1,183 @@
+//! Vigila la carpeta del escritorio para no tener que releerla cada tanto.
+//!
+//! El widget de archivos releía el directorio **cada diez segundos, siempre**:
+//! seis veces por minuto, con sus `stat` y la resolución del icono de cada
+//! archivo, esté mirando alguien o no y haya cambiado algo o no. Y como el
+//! escritorio es una ventana de capa que nunca queda «oculta» para el navegador,
+//! pausar con `document.hidden` no lo habría salvado.
+//!
+//! Ahora el disco avisa. La relectura pasa a ocurrir cuando de verdad cambió
+//! algo, que es la única vez que hace falta.
+
+use inotify::{Inotify, WatchMask};
+use std::path::PathBuf;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+
+use crate::inotify_rafaga::esperar_rafaga;
+use crate::logger::{log_error, log_info};
+
+/// Se emite cuando cambió el contenido de la carpeta del escritorio.
+pub const DESKTOP_CHANGED_EVENT: &str = "desktop-files-changed";
+
+/// Una descarga crea el archivo, lo va escribiendo y lo renombra al final;
+/// descomprimir algo son cientos de creaciones seguidas. Se espera a que la
+/// ráfaga se apague para releer una vez y no una por archivo.
+const REPOSO: Duration = Duration::from_millis(400);
+
+/// La carpeta del escritorio según `user-dirs.dirs`, dado su contenido.
+///
+/// Separado de la lectura del archivo para poder probarlo: el formato admite
+/// comentarios, comillas y `$HOME`, y una carpeta mal resuelta deja el widget
+/// vigilando un directorio que no es el que muestra —de esos errores que no dan
+/// ningún síntoma más que «no se actualiza».
+pub fn escritorio_en_user_dirs(contenido: &str, home: &str) -> Option<PathBuf> {
+    for linea in contenido.lines() {
+        let linea = linea.trim();
+        if linea.starts_with('#') {
+            continue;
+        }
+
+        let Some(valor) = linea.strip_prefix("XDG_DESKTOP_DIR=") else {
+            continue;
+        };
+        let valor = valor.trim().trim_matches('"');
+        if valor.is_empty() {
+            continue;
+        }
+
+        return Some(PathBuf::from(valor.replace("$HOME", home)));
+    }
+
+    None
+}
+
+/// La carpeta del escritorio, o `$HOME/Desktop` si no hay configuración.
+///
+/// El mismo orden que usa el frontend, para que los dos miren la misma carpeta.
+fn directorio_del_escritorio() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+
+    let config = PathBuf::from(&home).join(".config").join("user-dirs.dirs");
+    if let Ok(contenido) = std::fs::read_to_string(&config) {
+        if let Some(ruta) = escritorio_en_user_dirs(&contenido, &home) {
+            return Some(ruta);
+        }
+    }
+
+    Some(PathBuf::from(home).join("Desktop"))
+}
+
+/// Avisa al frontend cada vez que cambia el contenido del escritorio.
+pub fn watch_desktop_dir(app: &AppHandle) {
+    let app = app.clone();
+
+    std::thread::spawn(move || {
+        let Some(directorio) = directorio_del_escritorio() else {
+            log_error("Sin HOME no se puede ubicar la carpeta del escritorio; el widget de archivos no se actualizará solo.");
+            return;
+        };
+
+        let mut inotify = match Inotify::init() {
+            Ok(inotify) => inotify,
+            Err(error) => {
+                log_error(&format!(
+                    "No se pudo iniciar inotify para el escritorio: {}. El widget de archivos no se actualizará solo.",
+                    error
+                ));
+                return;
+            }
+        };
+
+        // ATTRIB además de los cambios de contenido: un `chmod +x` cambia el
+        // icono que se muestra sin crear ni borrar nada.
+        let mask = WatchMask::CREATE
+            | WatchMask::DELETE
+            | WatchMask::MOVED_TO
+            | WatchMask::MOVED_FROM
+            | WatchMask::CLOSE_WRITE
+            | WatchMask::ATTRIB;
+
+        if let Err(error) = inotify.watches().add(&directorio, mask) {
+            log_error(&format!(
+                "Sin vigilancia sobre {}: {}. El widget de archivos no se actualizará solo.",
+                directorio.display(),
+                error
+            ));
+            return;
+        }
+
+        log_info(&format!(
+            "Vigilando {} para el widget de archivos",
+            directorio.display()
+        ));
+
+        let mut buffer = [0u8; 4096];
+
+        loop {
+            match esperar_rafaga(&mut inotify, &mut buffer, REPOSO) {
+                Ok(()) => {
+                    let _ = app.emit(DESKTOP_CHANGED_EVENT, ());
+                }
+                Err(error) => {
+                    log_error(&format!(
+                        "Vigilancia del escritorio interrumpida: {}",
+                        error
+                    ));
+                    return;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn se_resuelve_home_y_se_sacan_las_comillas() {
+        let contenido = "XDG_DOWNLOAD_DIR=\"$HOME/Descargas\"\nXDG_DESKTOP_DIR=\"$HOME/Escritorio\"\n";
+        assert_eq!(
+            escritorio_en_user_dirs(contenido, "/home/pato"),
+            Some(PathBuf::from("/home/pato/Escritorio"))
+        );
+    }
+
+    #[test]
+    fn una_ruta_absoluta_se_toma_tal_cual() {
+        assert_eq!(
+            escritorio_en_user_dirs("XDG_DESKTOP_DIR=\"/mnt/datos/escritorio\"", "/home/pato"),
+            Some(PathBuf::from("/mnt/datos/escritorio"))
+        );
+    }
+
+    #[test]
+    fn los_comentarios_no_cuentan() {
+        // Si contara, el widget vigilaría una carpeta equivocada y no se
+        // actualizaría nunca, sin ningún mensaje de error.
+        let contenido = "# XDG_DESKTOP_DIR=\"$HOME/Viejo\"\nXDG_DESKTOP_DIR=\"$HOME/Escritorio\"\n";
+        assert_eq!(
+            escritorio_en_user_dirs(contenido, "/home/pato"),
+            Some(PathBuf::from("/home/pato/Escritorio"))
+        );
+    }
+
+    #[test]
+    fn sin_la_clave_no_se_inventa_nada() {
+        assert_eq!(
+            escritorio_en_user_dirs("XDG_MUSIC_DIR=\"$HOME/Musica\"", "/home/pato"),
+            None
+        );
+        // Y una clave vacía tampoco vale: vigilar "" no falla, no hace nada.
+        assert_eq!(escritorio_en_user_dirs("XDG_DESKTOP_DIR=\"\"", "/home/pato"), None);
+    }
+
+    #[test]
+    fn una_carpeta_con_acentos_o_espacios_sobrevive() {
+        assert_eq!(
+            escritorio_en_user_dirs("XDG_DESKTOP_DIR=\"$HOME/Mi Escritorio Ñ\"", "/home/pato"),
+            Some(PathBuf::from("/home/pato/Mi Escritorio Ñ"))
+        );
+    }
+}

--- a/src-tauri/src/inotify_rafaga.rs
+++ b/src-tauri/src/inotify_rafaga.rs
@@ -1,0 +1,132 @@
+//! Esperar cambios en el disco sin despertar cuando no pasa nada.
+//!
+//! Los dos vigilantes del escritorio —el del menú y el de los archivos— tienen
+//! el mismo problema: los cambios llegan en ráfaga (un gestor de paquetes
+//! escribe cientos de archivos seguidos, una descarga crea y renombra) y actuar
+//! por cada evento significa rehacer el mismo trabajo muchas veces. Pero
+//! esperar a que la ráfaga se apague no debería costar despertares.
+
+use inotify::Inotify;
+use std::time::Duration;
+
+/// Espera a que haya cambios y a que dejen de haberlos.
+///
+/// Bloquea en el kernel hasta el primer evento —mientras no pasa nada, el hilo
+/// no despierta ni una vez— y después va drenando hasta que pasa `reposo` sin
+/// novedades. Recién ahí vuelve, y el llamador hace su trabajo una sola vez.
+///
+/// La forma anterior era un `read_events` no bloqueante seguido de
+/// `sleep(200ms)` en un bucle: correcto, pero **cinco despertares por segundo
+/// para siempre**, unos 144 mil en una jornada de ocho horas, casi todos para
+/// descubrir que no había nada. El costo de cada uno es chico; el de tenerlos
+/// dos veces en el proceso que dibuja el escritorio, no tanto.
+pub fn esperar_rafaga(
+    inotify: &mut Inotify,
+    buffer: &mut [u8],
+    reposo: Duration,
+) -> std::io::Result<()> {
+    // `read_events_blocking` pone el descriptor en modo bloqueante y lo
+    // restaura al volver, así que se puede alternar con `read_events` sin
+    // tocar nada a mano.
+    if inotify.read_events_blocking(buffer)?.count() == 0 {
+        return Ok(());
+    }
+
+    loop {
+        std::thread::sleep(reposo);
+
+        match inotify.read_events(buffer) {
+            Ok(eventos) => {
+                // Sigue llegando: la ráfaga no terminó.
+                if eventos.count() == 0 {
+                    return Ok(());
+                }
+            }
+            // Sin eventos pendientes es justamente la señal de que se apagó, no
+            // un error.
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use inotify::WatchMask;
+
+    /// Un directorio propio para no pisar a otro test que corra a la par.
+    fn directorio_de_prueba(nombre: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("vsk-rafaga-{}-{}", std::process::id(), nombre));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("crear el directorio de prueba");
+        dir
+    }
+
+    /// Que despierte cuando algo cambia, y no antes.
+    ///
+    /// Las dos mitades importan: si no despertara, el widget de archivos no se
+    /// actualizaría nunca —que es peor que releer cada diez segundos—, y si
+    /// despertara sin cambios volveríamos al sondeo que este módulo vino a
+    /// sacar.
+    #[test]
+    fn despierta_cuando_cambia_el_directorio_y_espera_a_que_la_rafaga_termine() {
+        let dir = directorio_de_prueba("cambia");
+        let mut inotify = Inotify::init().expect("inotify");
+        inotify
+            .watches()
+            .add(&dir, WatchMask::CREATE | WatchMask::CLOSE_WRITE)
+            .expect("vigilar");
+
+        let reposo = Duration::from_millis(150);
+        let escritor = dir.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(200));
+            // Una ráfaga, como una descarga que se descomprime.
+            for i in 0..5 {
+                let _ = std::fs::write(escritor.join(format!("archivo-{i}")), b"x");
+                std::thread::sleep(Duration::from_millis(30));
+            }
+        });
+
+        let inicio = std::time::Instant::now();
+        let mut buffer = [0u8; 4096];
+        esperar_rafaga(&mut inotify, &mut buffer, reposo).expect("esperar");
+        let tardanza = inicio.elapsed();
+
+        assert!(
+            tardanza >= Duration::from_millis(200),
+            "no puede volver antes de que haya un cambio; volvió en {tardanza:?}"
+        );
+        assert!(
+            tardanza >= Duration::from_millis(200) + reposo,
+            "tiene que esperar a que la ráfaga se apague antes de avisar; volvió en {tardanza:?}"
+        );
+
+        // Y una sola vez para las cinco escrituras: eso es el punto del reposo.
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Sin cambios no vuelve, que es lo que ahorra los despertares. Se comprueba
+    /// por el negativo: en medio segundo largo sin tocar nada, no volvió.
+    #[test]
+    fn sin_cambios_no_vuelve() {
+        let dir = directorio_de_prueba("quieto");
+        let mut inotify = Inotify::init().expect("inotify");
+        inotify.watches().add(&dir, WatchMask::CREATE).expect("vigilar");
+
+        let (aviso, recibo) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let mut buffer = [0u8; 4096];
+            let _ = esperar_rafaga(&mut inotify, &mut buffer, Duration::from_millis(50));
+            let _ = aviso.send(());
+        });
+
+        assert!(
+            recibo.recv_timeout(Duration::from_millis(600)).is_err(),
+            "volvió sin que nada cambiara: eso es sondear, no escuchar"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,8 @@ fn default_locale() -> String {
 }
 
 mod menu_manager;
+mod desktop_watcher;
+mod inotify_rafaga;
 mod menu_watcher;
 mod monitor_manager;
 mod notifications;
@@ -269,6 +271,9 @@ pub fn run() {
             }
             watch_monitor_changes(&handle);
             menu_watcher::watch_application_dirs(&handle);
+            // La carpeta del escritorio, para que el widget de archivos deje de
+            // releerla cada diez segundos sin motivo.
+            desktop_watcher::watch_desktop_dir(&handle);
 
             // Retry in the background instead of aborting startup.
             //

--- a/src-tauri/src/menu_watcher.rs
+++ b/src-tauri/src/menu_watcher.rs
@@ -1,7 +1,8 @@
 use inotify::{Inotify, WatchMask};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 
+use crate::inotify_rafaga::esperar_rafaga;
 use crate::logger::{log_error, log_info};
 use crate::menu_manager::{applications_dirs, invalidate_menu_cache};
 
@@ -67,34 +68,22 @@ pub fn watch_application_dirs(app: &AppHandle) {
         ));
 
         let mut buffer = [0u8; 4096];
-        let mut pending: Option<Instant> = None;
 
         loop {
-            // A short read timeout lets the loop notice a burst has settled
-            // without waiting for another unrelated event to wake it.
-            match inotify.read_events(&mut buffer) {
-                Ok(events) => {
-                    if events.count() > 0 {
-                        pending = Some(Instant::now());
-                    }
+            // Bloquea hasta que algo cambie. Antes este bucle sondeaba a 5 Hz
+            // para siempre —unos 144 mil despertares en ocho horas— y casi
+            // todos eran para descubrir que no había nada.
+            match esperar_rafaga(&mut inotify, &mut buffer, SETTLE) {
+                Ok(()) => {
+                    invalidate_menu_cache();
+                    log_info("Cambió la lista de aplicaciones; menú invalidado");
+                    let _ = app.emit(MENU_CHANGED_EVENT, ());
                 }
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
                 Err(error) => {
                     log_error(&format!("Vigilancia del menú interrumpida: {}", error));
                     return;
                 }
             }
-
-            if let Some(since) = pending {
-                if since.elapsed() >= SETTLE {
-                    pending = None;
-                    invalidate_menu_cache();
-                    log_info("Cambió la lista de aplicaciones; menú invalidado");
-                    let _ = app.emit(MENU_CHANGED_EVENT, ());
-                }
-            }
-
-            std::thread::sleep(Duration::from_millis(200));
         }
     });
 }

--- a/src/components/widgets/FilesWidget.vue
+++ b/src/components/widgets/FilesWidget.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { listen } from '@tauri-apps/api/event';
 import { homeDir } from '@tauri-apps/api/path';
 import { Command } from '@tauri-apps/plugin-shell';
 import { useConfigStore } from '@vasakgroup/plugin-config-manager';
@@ -62,17 +63,29 @@ async function abrir(file: FileEntry) {
 	}
 }
 
-let recarga: ReturnType<typeof setInterval> | null = null;
+let dejarDeEscuchar: (() => void) | null = null;
 
 onMounted(() => {
 	void cargar();
+
 	// El escritorio cambia por fuera de la aplicación —se descarga algo, se
-	// borra un archivo—, así que se relee cada tanto. Barato: es un directorio.
-	recarga = setInterval(() => void cargar(), 10_000);
+	// borra un archivo— y hay que enterarse. Antes esto se releía cada diez
+	// segundos: seis veces por minuto, con un `stat` y la resolución del icono
+	// de cada archivo, hubiera cambiado algo o no. Ahora avisa el disco, así que
+	// la relectura ocurre cuando de verdad hace falta.
+	//
+	// Y no alcanzaba con pausar por `document.hidden`: el escritorio es una
+	// ventana de capa que nunca queda oculta para el navegador, aunque esté
+	// tapada por todas las ventanas abiertas.
+	listen('desktop-files-changed', () => void cargar())
+		.then((soltar) => {
+			dejarDeEscuchar = soltar;
+		})
+		.catch((error) => logError(`No se pudo escuchar los cambios del escritorio: ${error}`));
 });
 
 onUnmounted(() => {
-	if (recarga) clearInterval(recarga);
+	dejarDeEscuchar?.();
 });
 
 watch(showHidden, () => void cargar());

--- a/src/components/widgets/FilesWidget.vue
+++ b/src/components/widgets/FilesWidget.vue
@@ -63,7 +63,7 @@ async function abrir(file: FileEntry) {
 	}
 }
 
-let dejarDeEscuchar: (() => void) | null = null;
+let promesaDeEscucha: Promise<() => void> | null = null;
 
 onMounted(() => {
 	void cargar();
@@ -77,15 +77,25 @@ onMounted(() => {
 	// Y no alcanzaba con pausar por `document.hidden`: el escritorio es una
 	// ventana de capa que nunca queda oculta para el navegador, aunque esté
 	// tapada por todas las ventanas abiertas.
-	listen('desktop-files-changed', () => void cargar())
-		.then((soltar) => {
-			dejarDeEscuchar = soltar;
-		})
-		.catch((error) => logError(`No se pudo escuchar los cambios del escritorio: ${error}`));
+	// Se guarda la promesa, no el resultado. `listen` resuelve después, y si el
+	// componente se desmonta antes de que resuelva —al cambiar de widget, o al
+	// cerrar la ventana enseguida— `onUnmounted` no encontraba ninguna función que
+	// llamar: el escucha quedaba vivo y podía releer el directorio de un
+	// componente ya desmontado.
+	promesaDeEscucha = listen('desktop-files-changed', () => void cargar());
+	promesaDeEscucha.catch((error) =>
+		logError(`No se pudo escuchar los cambios del escritorio: ${error}`)
+	);
 });
 
 onUnmounted(() => {
-	dejarDeEscuchar?.();
+	promesaDeEscucha
+		?.then((soltar) => soltar())
+		.catch(() => {
+			// Si nunca llegó a enganchar, no hay nada que soltar. El error ya se
+			// informó arriba.
+		});
+	promesaDeEscucha = null;
 });
 
 watch(showHidden, () => void cargar());

--- a/src/tools/composables/escucha-de-visibilidad.test.ts
+++ b/src/tools/composables/escucha-de-visibilidad.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	crearEscuchaDeVisibilidad,
+	type DocumentoObservable,
+} from '@/tools/composables/escucha-de-visibilidad';
+
+/** Un `document` de juguete que cuenta lo que se le engancha y se le saca. */
+function documentoFalso() {
+	const manejadores = new Set<() => void>();
+	let enganches = 0;
+	let desenganches = 0;
+	const doc: DocumentoObservable & {
+		disparar(): void;
+		enganches(): number;
+		desenganches(): number;
+		vivos(): number;
+	} = {
+		hidden: false,
+		addEventListener(_tipo, manejador) {
+			manejadores.add(manejador);
+			enganches += 1;
+		},
+		removeEventListener(_tipo, manejador) {
+			manejadores.delete(manejador);
+			desenganches += 1;
+		},
+		disparar() {
+			for (const m of [...manejadores]) m();
+		},
+		enganches: () => enganches,
+		desenganches: () => desenganches,
+		vivos: () => manejadores.size,
+	};
+	return doc;
+}
+
+describe('crearEscuchaDeVisibilidad', () => {
+	test('soltar deja el documento sin escuchas', () => {
+		// El bug: al desmontarse el último consumidor el escucha quedaba vivo, y
+		// esconder y mostrar la ventana seguía disparando trabajo sin nadie
+		// mirando.
+		const doc = documentoFalso();
+		let veces = 0;
+		const escucha = crearEscuchaDeVisibilidad(doc, () => {
+			veces += 1;
+		});
+
+		escucha.enganchar();
+		doc.disparar();
+		expect(veces).toBe(1);
+
+		escucha.soltar();
+		expect(doc.vivos()).toBe(0);
+		doc.disparar();
+		expect(veces).toBe(1);
+	});
+
+	test('enganchar dos veces no duplica el escucha', () => {
+		// Con dos enganchados, cada vuelta de la ventana haría el trabajo dos
+		// veces, y soltar una sola dejaría el otro vivo.
+		const doc = documentoFalso();
+		const escucha = crearEscuchaDeVisibilidad(doc, () => {});
+
+		escucha.enganchar();
+		escucha.enganchar();
+		expect(doc.enganches()).toBe(1);
+
+		escucha.soltar();
+		expect(doc.vivos()).toBe(0);
+	});
+
+	test('soltar sin haber enganchado no toca el documento', () => {
+		const doc = documentoFalso();
+		crearEscuchaDeVisibilidad(doc, () => {}).soltar();
+		expect(doc.desenganches()).toBe(0);
+	});
+
+	test('sólo avisa cuando la ventana está a la vista', () => {
+		// Al esconderse no hay que refrescar nada: es justo lo que la pausa evita.
+		const doc = documentoFalso();
+		let veces = 0;
+		const escucha = crearEscuchaDeVisibilidad(doc, () => {
+			veces += 1;
+		});
+		escucha.enganchar();
+
+		doc.hidden = true;
+		doc.disparar();
+		expect(veces).toBe(0);
+
+		doc.hidden = false;
+		doc.disparar();
+		expect(veces).toBe(1);
+	});
+
+	test('sin document no explota ni queda enganchado', () => {
+		// Al arrancar una ventana de Tauri no siempre hay uno.
+		const escucha = crearEscuchaDeVisibilidad(undefined, () => {});
+		escucha.enganchar();
+		expect(escucha.enganchado()).toBe(false);
+		escucha.soltar();
+	});
+});

--- a/src/tools/composables/escucha-de-visibilidad.ts
+++ b/src/tools/composables/escucha-de-visibilidad.ts
@@ -1,0 +1,51 @@
+/**
+ * Un escucha de `visibilitychange` que se puede soltar.
+ *
+ * Vive aparte porque el error está justo acá y no se ve mirando el código: con un
+ * booleano marcando «ya enganché», al desmontarse el último consumidor se
+ * limpiaba el temporizador y **el escucha quedaba enganchado para siempre**. Un
+ * ciclo de esconder y mostrar la ventana seguía disparando trabajo —un IPC, y a
+ * veces un pedido a la red— sin que quedara nadie mirando el dato.
+ *
+ * Recibe el `document` en lugar de tomarlo del entorno para poder probarlo, y
+ * porque en el arranque de una ventana de Tauri no siempre hay uno.
+ */
+export interface DocumentoObservable {
+	hidden: boolean;
+	addEventListener(tipo: string, manejador: () => void): void;
+	removeEventListener(tipo: string, manejador: () => void): void;
+}
+
+export interface EscuchaDeVisibilidad {
+	/** Engancha, si no estaba enganchado. Llamarlo dos veces no duplica nada. */
+	enganchar(): void;
+	/** Suelta. Llamarlo sin haber enganchado no hace nada. */
+	soltar(): void;
+	/** Si está enganchado ahora mismo. */
+	enganchado(): boolean;
+}
+
+export function crearEscuchaDeVisibilidad(
+	documento: DocumentoObservable | undefined,
+	alVolverALaVista: () => void
+): EscuchaDeVisibilidad {
+	let manejador: (() => void) | null = null;
+
+	return {
+		enganchar() {
+			if (manejador || !documento) return;
+			manejador = () => {
+				if (!documento.hidden) alVolverALaVista();
+			};
+			documento.addEventListener('visibilitychange', manejador);
+		},
+		soltar() {
+			if (!manejador || !documento) return;
+			documento.removeEventListener('visibilitychange', manejador);
+			manejador = null;
+		},
+		enganchado() {
+			return manejador !== null;
+		},
+	};
+}

--- a/src/tools/composables/useWeather.ts
+++ b/src/tools/composables/useWeather.ts
@@ -9,6 +9,7 @@ import {
 	weatherRelease,
 	weatherStore,
 } from '@/services/weather.service';
+import { crearEscuchaDeVisibilidad } from '@/tools/composables/escucha-de-visibilidad';
 import { logError } from '@/utils/logger';
 
 /**
@@ -50,7 +51,18 @@ function aLaVista(): boolean {
 let arrancado = false;
 let reloj: ReturnType<typeof setInterval> | undefined;
 let consumidores = 0;
-let escuchandoVisibilidad = false;
+/**
+ * El escucha que refresca al volver la ventana a la vista.
+ *
+ * Se suelta cuando se desmonta el último consumidor. Con un booleano marcando
+ * «ya enganché» no había forma de soltarlo: quedaba vivo para siempre, y un ciclo
+ * de esconder y mostrar seguía disparando un IPC —y a veces un pedido a la red—
+ * sin que hubiera nadie mirando el clima. Ver `escucha-de-visibilidad.ts`.
+ */
+const escuchaDeVisibilidad = crearEscuchaDeVisibilidad(
+	typeof document === 'undefined' ? undefined : document,
+	() => void refrescar()
+);
 
 /**
  * Coordenadas a partir de la zona horaria.
@@ -163,19 +175,19 @@ export function useWeather() {
 
 	// Al volver a la vista se revisa enseguida, sin esperar hasta un minuto: si
 	// estuvo escondida un rato largo, lo guardado puede haber vencido hace mucho.
-	if (!escuchandoVisibilidad && typeof document !== 'undefined') {
-		escuchandoVisibilidad = true;
-		document.addEventListener('visibilitychange', () => {
-			if (aLaVista()) void refrescar();
-		});
-	}
+	escuchaDeVisibilidad.enganchar();
 
 	onUnmounted(() => {
 		consumidores -= 1;
-		if (consumidores <= 0 && reloj) {
+		if (consumidores > 0) return;
+
+		if (reloj) {
 			clearInterval(reloj);
 			reloj = undefined;
 		}
+		// Y el escucha con él: sin nadie mirando, esconder y mostrar la ventana no
+		// tiene que disparar ningún trabajo.
+		escuchaDeVisibilidad.soltar();
 	});
 
 	const actual = computed(() => datos.value?.current ?? null);

--- a/src/tools/composables/useWeather.ts
+++ b/src/tools/composables/useWeather.ts
@@ -35,9 +35,22 @@ const LIMITE = 10_000;
 /** Cada cuánto se revisa si lo guardado venció. No toca la red. */
 const REVISION = 60_000;
 
+/**
+ * Si esta ventana está a la vista.
+ *
+ * La revisión del minuto no toca la red, pero sí cruza el IPC para preguntarle a
+ * Rust si le toca pedir. Hacerlo mientras la ventana está escondida —el panel
+ * cerrado, el menú sin abrir— es preguntar por un dato que nadie está mirando: el
+ * clima no cambia en un minuto, y al volver a mostrarse se revisa igual.
+ */
+function aLaVista(): boolean {
+	return typeof document === 'undefined' || !document.hidden;
+}
+
 let arrancado = false;
 let reloj: ReturnType<typeof setInterval> | undefined;
 let consumidores = 0;
+let escuchandoVisibilidad = false;
 
 /**
  * Coordenadas a partir de la zona horaria.
@@ -142,7 +155,20 @@ export function useWeather() {
 	consumidores += 1;
 	void arrancar();
 
-	if (!reloj) reloj = setInterval(() => void refrescar(), REVISION);
+	if (!reloj) {
+		reloj = setInterval(() => {
+			if (aLaVista()) void refrescar();
+		}, REVISION);
+	}
+
+	// Al volver a la vista se revisa enseguida, sin esperar hasta un minuto: si
+	// estuvo escondida un rato largo, lo guardado puede haber vencido hace mucho.
+	if (!escuchandoVisibilidad && typeof document !== 'undefined') {
+		escuchandoVisibilidad = true;
+		document.addEventListener('visibilitychange', () => {
+			if (aLaVista()) void refrescar();
+		});
+	}
 
 	onUnmounted(() => {
 		consumidores -= 1;


### PR DESCRIPTION
…undos

Tres sondeos que quedaban del barrido anterior.

**El widget de archivos** releía la carpeta del escritorio cada diez segundos, siempre: seis veces por minuto, con el `stat` y la resolución del icono de cada archivo, hubiera cambiado algo o no y estuviera mirando alguien o no. Y no alcanzaba con pausar por `document.hidden`: el escritorio es una ventana de capa que nunca queda oculta para el navegador, aunque esté tapada por todas las ventanas abiertas. Ahora avisa inotify y la relectura ocurre cuando de verdad cambió algo.

**El vigilante del menú** ya escuchaba inotify, pero con un `read_events` no bloqueante y `sleep(200ms)` en bucle: cinco despertares por segundo para siempre, unos 144 mil en una jornada de ocho horas, casi todos para descubrir que no había nada. Ahora bloquea en el kernel hasta el primer evento. La espera a que la ráfaga se apague —que es lo que evita rehacer el trabajo por cada archivo que escribe un gestor de paquetes— quedó en `inotify_rafaga.rs`, compartida por los dos vigilantes.

**El clima** revisaba cada minuto si lo guardado venció. No toca la red, pero sí cruza el IPC para preguntarle a Rust si le toca pedir, y hacerlo con la ventana escondida es preguntar por un dato que nadie mira. Ahora pausa mientras está oculta y revisa al volver a la vista, que es cuando importa.

7 tests nuevos: la resolución de la carpeta desde `user-dirs.dirs` (con comentarios, `$HOME`, comillas, acentos y espacios — una carpeta mal resuelta deja el widget vigilando otra cosa sin dar ningún síntoma), y dos sobre inotify de verdad: que despierte cuando algo cambia y espere a que la ráfaga termine, y que **no** vuelva cuando nada cambió, que es lo que ahorra los despertares.

73 tests en Rust, 22 en el frontend, clippy en cero, vue-tsc limpio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop file changes now appear automatically without waiting for periodic polling.
  * File and menu updates are processed after bursts of filesystem activity settle.

* **Bug Fixes**
  * Weather updates now refresh immediately when a window becomes visible.
  * Hidden windows avoid unnecessary weather refresh activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->