### PR TITLE
i18n: las teclas del buscador, y tests de catálogos

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5865,6 +5865,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "shlex 1.3.0",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,6 +65,8 @@ tauri-plugin-vsk-contextual-menu = "2"
 
 
 [dev-dependencies]
+# Sólo para el test que valida los catálogos de idioma.
+serde_yaml = "0.9"
 proptest = "1"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/locales/en.yml
+++ b/src-tauri/locales/en.yml
@@ -83,6 +83,8 @@ views:
     videoWallpaperPowerTitle: A moving wallpaper uses more power
     videoWallpaperPowerBody: A video wallpaper keeps the system working all the time and drains more battery than an image. It can pause automatically on battery from Settings › Appearance › Wallpaper.
   search:
+    keyEnter: Enter
+    keyEsc: Esc
     iconAlt: Search
     placeholder: Search apps, files and actions...
     hint: Type to search apps, files or actions

--- a/src-tauri/locales/es.yml
+++ b/src-tauri/locales/es.yml
@@ -83,6 +83,8 @@ views:
     videoWallpaperPowerTitle: El fondo en movimiento consume más
     videoWallpaperPowerBody: Un video de fondo mantiene el sistema trabajando todo el tiempo y gasta más batería que una imagen. Se puede pausar automáticamente con batería desde Configuración › Apariencia › Fondo.
   search:
+    keyEnter: Intro
+    keyEsc: Esc
     iconAlt: Buscar
     placeholder: Buscar aplicaciones, archivos y acciones...
     hint: Escribe para buscar aplicaciones, archivos o acciones

--- a/src-tauri/tests/locales.rs
+++ b/src-tauri/tests/locales.rs
@@ -1,0 +1,131 @@
+//! Que los catálogos de idioma sirvan.
+//!
+//! El plugin de i18n los parsea en tiempo de ejecución y **paniquea** si no
+//! puede, así que un error de sintaxis no se ve hasta que la aplicación no
+//! arranca. Y una clave que falta en un idioma no falla: se muestra cruda, con
+//! el nombre de la clave a la vista de la persona.
+//!
+//! Estos tests aparecieron al mover el bloque de permisos de `views.privacy` a
+//! `views.onlineAccounts.permissions`: reindentar un bloque de veinte líneas a
+//! mano en dos archivos es exactamente donde se pierde una clave.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+fn catalogo(idioma: &str) -> serde_yaml::Value {
+    let ruta = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("locales")
+        .join(format!("{idioma}.yml"));
+    let texto = std::fs::read_to_string(&ruta)
+        .unwrap_or_else(|e| panic!("no se pudo leer {}: {e}", ruta.display()));
+    serde_yaml::from_str(&texto)
+        .unwrap_or_else(|e| panic!("{} no es YAML válido: {e}", ruta.display()))
+}
+
+/// Todas las claves, aplanadas con puntos, como las busca el plugin.
+fn claves(valor: &serde_yaml::Value, prefijo: &str, salida: &mut BTreeSet<String>) {
+    match valor {
+        serde_yaml::Value::Mapping(mapa) => {
+            for (clave, hijo) in mapa {
+                let nombre = clave.as_str().unwrap_or_default();
+                let completa = if prefijo.is_empty() {
+                    nombre.to_string()
+                } else {
+                    format!("{prefijo}.{nombre}")
+                };
+                claves(hijo, &completa, salida);
+            }
+        }
+        _ => {
+            salida.insert(prefijo.to_string());
+        }
+    }
+}
+
+fn claves_de(idioma: &str) -> BTreeSet<String> {
+    let mut salida = BTreeSet::new();
+    claves(&catalogo(idioma), "", &mut salida);
+    salida
+}
+
+#[test]
+fn los_dos_idiomas_parsean_y_la_raiz_es_un_mapeo() {
+    for idioma in ["es", "en"] {
+        let raiz = catalogo(idioma);
+        assert!(
+            raiz.is_mapping(),
+            "la raíz de {idioma}.yml tiene que ser un mapeo, no un valor suelto"
+        );
+    }
+}
+
+#[test]
+fn los_dos_idiomas_tienen_las_mismas_claves() {
+    let es = claves_de("es");
+    let en = claves_de("en");
+
+    let solo_es: Vec<_> = es.difference(&en).collect();
+    let solo_en: Vec<_> = en.difference(&es).collect();
+
+    assert!(
+        solo_es.is_empty() && solo_en.is_empty(),
+        "las claves no coinciden.\n  sólo en es: {solo_es:?}\n  sólo en en: {solo_en:?}"
+    );
+}
+
+#[test]
+fn ningun_texto_esta_vacio() {
+    // Una clave vacía no es un texto faltante que se note: se muestra como nada,
+    // y el control queda sin etiqueta.
+    for idioma in ["es", "en"] {
+        let raiz = catalogo(idioma);
+        let mut vacias = Vec::new();
+        let mut todas = BTreeSet::new();
+        claves(&raiz, "", &mut todas);
+
+        for clave in &todas {
+            let mut actual = &raiz;
+            for parte in clave.split('.') {
+                actual = &actual[parte];
+            }
+            if actual.as_str().map(|s| s.trim().is_empty()).unwrap_or(false) {
+                vacias.push(clave.clone());
+            }
+        }
+        assert!(vacias.is_empty(), "textos vacíos en {idioma}.yml: {vacias:?}");
+    }
+}
+
+#[test]
+fn los_marcadores_de_interpolacion_coinciden() {
+    // Un `{0}` que está en un idioma y no en el otro pierde el dato: el texto
+    // sale sin el nombre del proveedor, sin el error, sin el número.
+    let es = catalogo("es");
+    let en = catalogo("en");
+    let mut todas = BTreeSet::new();
+    claves(&es, "", &mut todas);
+
+    let marcadores = |v: &serde_yaml::Value| -> Vec<String> {
+        let texto = v.as_str().unwrap_or_default();
+        let mut encontrados: Vec<String> = texto
+            .match_indices('{')
+            .filter_map(|(i, _)| texto[i..].find('}').map(|j| texto[i..i + j + 1].to_string()))
+            .collect();
+        encontrados.sort();
+        encontrados
+    };
+
+    for clave in &todas {
+        let mut a = &es;
+        let mut b = &en;
+        for parte in clave.split('.') {
+            a = &a[parte];
+            b = &b[parte];
+        }
+        assert_eq!(
+            marcadores(a),
+            marcadores(b),
+            "los marcadores de «{clave}» no coinciden entre idiomas"
+        );
+    }
+}

--- a/src/views/apps/SearchView.vue
+++ b/src/views/apps/SearchView.vue
@@ -298,14 +298,14 @@ function getCategoryLabel(category: string): string {
             <span class="flex items-center gap-1">
               <kbd
                 class="bg-primary/15 px-2 py-1 rounded border border-primary/20 text-primary font-semibold"
-                >Enter</kbd
+                >{{ t('views.search.keyEnter') }}</kbd
               >
               {{ t('views.search.keyExecute') }}
             </span>
             <span class="flex items-center gap-1">
               <kbd
                 class="bg-primary/15 px-2 py-1 rounded border border-primary/20 text-primary font-semibold"
-                >Esc</kbd
+                >{{ t('views.search.keyEsc') }}</kbd
               >
               {{ t('views.search.keyClose') }}
             </span>


### PR DESCRIPTION
El escritorio estaba prácticamente limpio: **cero** cadenas literales en TypeScript, y de las ocho en plantillas, seis son nombres propios —Bluetooth, Wi-Fi, Ethernet, VPN, Twingate— que no se traducen en ningún idioma y quedan como están. Agregarlos al catálogo sería una clave repetida en los dos archivos y trabajo de mantenimiento sin beneficio.

Las dos que sí eran texto: «Enter» y «Esc», las teclas que el buscador sugiere. En un teclado español esa tecla dice «Intro», así que ahora la decisión vive en el catálogo en lugar de estar clavada en la plantilla.

Y 4 tests de catálogos, que el repo no tenía: que los dos idiomas parseen, que tengan las mismas claves, que ningún texto quede vacío y que los marcadores de interpolación coincidan. Los cuatro cubren cosas que **no fallan**, sólo se ven mal: una clave que falta se muestra cruda con su nombre a la vista, un texto vacío deja un control sin etiqueta, y un `{0}` que está en un idioma y no en el otro pierde el dato que iba ahí.

En el gestor de archivos los mismos tests encontraron dos bugs de una: una clave duplicada y dos que estaban sólo en inglés.

tsc y biome limpios, 27 tests del frontend, 4 de catálogos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added localized Enter and Escape keyboard hints to the search interface in English and Spanish.
  * Search keyboard labels now adapt to the selected language.

* **Tests**
  * Added validation to ensure language catalogs remain consistent, complete, and correctly formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->