### PR TITLE
feat: el diario del sistema, con el nombre de esta aplicación

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@vasakgroup/plugin-user-data": "^2.0.0",
         "@vasakgroup/plugin-vicons": "^2.1.2",
         "@vasakgroup/plugin-vsk-contextual-menu": "2.0.2",
+        "@vasakgroup/plugin-vsk-journal": "^2.0.0",
         "@vasakgroup/tauri-plugin-i18n": "^2.1.0",
         "@vasakgroup/vue-libvasak": "~0.2.3",
         "pinia": "^3.0.4",
@@ -259,6 +260,8 @@
     "@vasakgroup/plugin-vicons": ["@vasakgroup/plugin-vicons@2.1.2", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-c7szP8mDMweiUmzpyxZuqK7Sdc5i3gTG+QevqCvF96J2/VIVmWFRnAz02e+dCucbgNKV4yuKfQPrlEy1d/sBhg=="],
 
     "@vasakgroup/plugin-vsk-contextual-menu": ["@vasakgroup/plugin-vsk-contextual-menu@2.0.2", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" }, "peerDependencies": { "vue": "^3.0.0" }, "optionalPeers": ["vue"] }, "sha512-DWt4tXftm0F32hyUMIxpmYFj3kzwcdsAI0x/9cNl7ZDyt9kBSrc8nAcvtw32D+H8kornnAMhcQoi4s/2HuLYfQ=="],
+
+    "@vasakgroup/plugin-vsk-journal": ["@vasakgroup/plugin-vsk-journal@2.0.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-UsFkQFym0kgM7aOIsrrtsE1F/XU6u0QkFRLYiVBWTCsMdDobn1BE+ca/Ym06l3tHqohNwDO8VbtGySlOAHPq1g=="],
 
     "@vasakgroup/tauri-plugin-i18n": ["@vasakgroup/tauri-plugin-i18n@2.1.0", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" }, "peerDependencies": { "vue": "^3.0.0" }, "optionalPeers": ["vue"] }, "sha512-zeM7pJc5b4BERCvkbrBQhvmqxLmlzqmIAkCIdJNIioS5uZwbvZsGDcgC6XqFn22TvNsj0zceTf55PM2byEUNsg=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@vasakgroup/plugin-user-data": "^2.0.0",
     "@vasakgroup/plugin-vicons": "^2.1.2",
     "@vasakgroup/plugin-vsk-contextual-menu": "2.0.2",
+    "@vasakgroup/plugin-vsk-journal": "^2.0.0",
     "@vasakgroup/tauri-plugin-i18n": "^2.1.0",
     "@vasakgroup/vue-libvasak": "~0.2.3",
     "pinia": "^3.0.4",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -105,7 +105,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -116,7 +116,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1088,7 +1088,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1347,7 +1347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2907,7 +2907,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3040,7 +3040,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3373,7 +3373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4140,7 +4140,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4565,7 +4565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5149,6 +5149,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-vsk-journal"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e191d030a25b63d9ead82ff31b7a6ef8317ac45024103d65240505e137d9208c"
+dependencies = [
+ "serde",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5258,7 +5270,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5673,7 +5685,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5702,7 +5714,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5881,6 +5893,7 @@ dependencies = [
  "tauri-plugin-user-data",
  "tauri-plugin-vicons",
  "tauri-plugin-vsk-contextual-menu",
+ "tauri-plugin-vsk-journal",
  "thiserror 2.0.20",
  "tokio",
  "url",
@@ -6238,7 +6251,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,7 @@ inotify = "0.10"
 parking_lot = "0.12"
 url = "2"
 tauri-plugin-vsk-contextual-menu = "2"
+tauri-plugin-vsk-journal = "2"
 
 
 [dev-dependencies]

--- a/src-tauri/capabilities/context-menu.json
+++ b/src-tauri/capabilities/context-menu.json
@@ -1,10 +1,13 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "context-menu",
-  "description": "La ventana del menú contextual: dibuja un menú y devuelve lo elegido, nada más.",
-  "windows": ["vsk_context_menu"],
+  "description": "La ventana del men\u00fa contextual: dibuja un men\u00fa y devuelve lo elegido, nada m\u00e1s.",
+  "windows": [
+    "vsk_context_menu"
+  ],
   "permissions": [
     "vsk-contextual-menu:default",
+    "vsk-journal:default",
     "config-manager:default"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -71,6 +71,7 @@
     "positioner:allow-move-window",
     "positioner:allow-set-tray-icon-state",
     "vsk-contextual-menu:default",
+    "vsk-journal:default",
     "vicons:default",
     "config-manager:default",
     "user-data:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,6 +133,11 @@ pub fn run() {
             locales_dir(),
         ))
         .plugin(tauri_plugin_opener::init())
+        // El diario del sistema, con el nombre de esta aplicación. Va **primero**
+        // de todos los plugins: instala el gancho de pánico, y un pánico mientras
+        // arranca otro plugin es de los más probables y de los que menos rastro
+        // dejan — sin esto sólo queda un volcado de núcleo sin símbolos.
+        .plugin(tauri_plugin_vsk_journal::init())
         .plugin(tauri_plugin_vsk_contextual_menu::init())
         .invoke_handler(tauri::generate_handler![
             batch_invoke,

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { createApp } from 'vue';
 import App from '@/App.vue';
 import { router } from '@/routes/index';
 import '@/assets/main.css';
+import { captureFailures } from '@vasakgroup/plugin-vsk-journal';
 
 /**
  * Los valores que la especificación de CSP informa en lugar de una URL.
@@ -83,6 +84,12 @@ setupContextMenu({ iconResolver: getIconSource });
 
 const pinia = createPinia();
 const i18n = I18n.getInstance();
+// Lo que rompe la interfaz va al diario del sistema, con el nombre de esta
+// aplicación. Antes no iba a ninguna parte: un error de JavaScript deja la
+// pantalla a medias y la consola del WebView no la ve nadie en una máquina
+// instalada.
+captureFailures();
+
 const app = createApp(App);
 
 i18n.load();


### PR DESCRIPTION
Una aplicación abierta desde el menú es hija del compositor, así que lo que manda por `stderr` cae en el diario atribuido a la unidad de la sesión y no a ella. Dos consecuencias, las dos medidas: el selector de aplicaciones del monitor decía «sin entradas» para todas las apps gráficas, y cuando `vasak-desktop` abortó lo único que quedó fue un volcado de núcleo sin símbolos —veinte marcos con `n/a`— porque el mensaje del panic fue a un `stderr` que después nadie podía leer.

Con `tauri-plugin-vsk-journal` cada entrada lleva el nombre de la aplicación, así que `journalctl -t <app>` y el selector del monitor la encuentran, y un campo que dice si salió de la interfaz o del núcleo.

El plugin va **primero** de todos: instala el gancho de pánico, y un pánico mientras arranca otro plugin es de los más probables y de los que menos rastro dejan. `captureFailures()` va antes de armar la aplicación, para que atrape también lo que falle durante el arranque de la interfaz.

Comprobado de punta a punta: una llamada desde la interfaz aparece con `journalctl -t <app>`, con su prioridad y su capa.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added application error and crash reporting to the system journal.
  * Interface-breaking JavaScript errors are now captured with the application name for easier troubleshooting.
  * Startup failures are recorded with traceable diagnostic information instead of producing only unsymbolized crash output.
* **Bug Fixes**
  * Improved visibility into failures that previously provided little or no accessible diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->