### PR TITLE
fix(panel): Telegram vuelve al panel y las notificaciones salen de la lista

### DIFF
--- a/src-tauri/src/menu_watcher.rs
+++ b/src-tauri/src/menu_watcher.rs
@@ -5,6 +5,7 @@ use tauri::{AppHandle, Emitter};
 use crate::inotify_rafaga::esperar_rafaga;
 use crate::logger::{log_error, log_info};
 use crate::menu_manager::{applications_dirs, invalidate_menu_cache};
+use crate::window_manager::app_icon::invalidate_icon_cache;
 
 /// Emitted when the installed application list changes.
 pub const MENU_CHANGED_EVENT: &str = "menu-items-changed";
@@ -76,6 +77,11 @@ pub fn watch_application_dirs(app: &AppHandle) {
             match esperar_rafaga(&mut inotify, &mut buffer, SETTLE) {
                 Ok(()) => {
                     invalidate_menu_cache();
+                    // El icono de cada ventana del panel también sale de los
+                    // `.desktop`, así que lo memorizado deja de valer acá
+                    // mismo: una aplicación recién instalada tiene que
+                    // aparecer con su icono y no con el `app-id` de reserva.
+                    invalidate_icon_cache();
                     log_info("Cambió la lista de aplicaciones; menú invalidado");
                     let _ = app.emit(MENU_CHANGED_EVENT, ());
                 }

--- a/src-tauri/src/window_manager/app_icon.rs
+++ b/src-tauri/src/window_manager/app_icon.rs
@@ -22,6 +22,7 @@
 use freedesktop_entry_parser::parse_entry;
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, RwLock};
 
 use crate::menu_manager::applications_dirs;
@@ -39,10 +40,18 @@ static RESOLVED: LazyLock<RwLock<HashMap<String, Option<String>>>> =
 /// Con más aplicaciones abiertas que esto, el escritorio tiene otro problema.
 const LIMITE_MEMORIZADO: usize = 512;
 
+/// Cuántas veces se invalidó lo memorizado. La búsqueda se hace **fuera** del
+/// cerrojo —leer archivos con el cerrojo de escritura tomado dejaría al panel
+/// esperando—, así que una invalidación puede caer justo en el medio: sin este
+/// contador, la búsqueda que empezó antes guardaría después su resultado viejo,
+/// y ese icono ya inválido se quedaría hasta el próximo cambio en el disco.
+static GENERACION: AtomicU64 = AtomicU64::new(0);
+
 /// Olvida lo resuelto. La llama el vigilante de `.desktop`: una aplicación
 /// recién instalada tiene que poder aparecer con su icono, y una que cambió el
 /// suyo tiene que dejar de mostrar el viejo.
 pub fn invalidate_icon_cache() {
+    GENERACION.fetch_add(1, Ordering::SeqCst);
     if let Ok(mut cache) = RESOLVED.write() {
         cache.clear();
     }
@@ -62,16 +71,32 @@ pub fn icon_for_app_id(app_id: &str) -> Option<String> {
         }
     }
 
+    // La generación se lee antes de buscar: si alguien invalida mientras se
+    // leen los `.desktop`, lo que se encontró ya no vale y no se guarda.
+    let generacion = GENERACION.load(Ordering::SeqCst);
     let resolved = lookup_icon(key);
-
-    if let Ok(mut cache) = RESOLVED.write() {
-        if cache.len() >= LIMITE_MEMORIZADO {
-            cache.clear();
-        }
-        cache.insert(key.to_string(), resolved.clone());
-    }
+    memorizar(key, resolved.clone(), generacion);
 
     resolved
+}
+
+/// Guarda lo resuelto, salvo que se haya invalidado mientras se buscaba.
+/// Devuelve si lo guardó.
+fn memorizar(key: &str, resolved: Option<String>, generacion: u64) -> bool {
+    if GENERACION.load(Ordering::SeqCst) != generacion {
+        return false;
+    }
+
+    match RESOLVED.write() {
+        Ok(mut cache) => {
+            if cache.len() >= LIMITE_MEMORIZADO {
+                cache.clear();
+            }
+            cache.insert(key.to_string(), resolved);
+            true
+        }
+        Err(_) => false,
+    }
 }
 
 /// La clave `Icon` de la entrada `.desktop` que corresponde a este `app-id`.
@@ -301,14 +326,19 @@ mod tests {
         assert_eq!(icon_for_app_id(""), None);
     }
 
+    /// Lo memorizado, de punta a punta, en una sola prueba.
+    ///
+    /// Va junto a propósito: `RESOLVED` y `GENERACION` son globales del proceso
+    /// y las pruebas corren en paralelo, así que repartir esto en varias hace
+    /// que una invalide mientras la otra comprueba lo que guardó.
     #[test]
-    fn lo_resuelto_queda_memorizado() {
-        // Incluye el resultado negativo: si no se guardara, cada evento del
-        // compositor volvería a recorrer todos los directorios de aplicaciones
-        // por cada ventana sin entrada.
+    fn lo_memorizado_se_guarda_se_invalida_y_no_acepta_resultados_viejos() {
         let inexistente = "vasak.prueba.que.no.existe";
         invalidate_icon_cache();
 
+        // El resultado negativo también se guarda: si no, cada evento del
+        // compositor volvería a recorrer todos los directorios de aplicaciones
+        // por cada ventana sin entrada.
         assert_eq!(icon_for_app_id(inexistente), None);
         assert!(
             RESOLVED
@@ -318,6 +348,7 @@ mod tests {
             "el resultado negativo no quedó memorizado"
         );
 
+        // Invalidar vacía.
         invalidate_icon_cache();
         assert!(
             !RESOLVED
@@ -326,5 +357,28 @@ mod tests {
                 .contains_key(inexistente),
             "invalidar no vació lo memorizado"
         );
+
+        // Y un resultado de antes de invalidar no se guarda. La búsqueda lee
+        // archivos sin el cerrojo tomado, así que puede terminar después de que
+        // alguien invalidó; guardarlo dejaría el icono viejo memorizado hasta el
+        // próximo cambio en el disco.
+        let generacion = GENERACION.load(Ordering::SeqCst);
+        invalidate_icon_cache();
+        assert!(
+            !memorizar(inexistente, Some("viejo".into()), generacion),
+            "se guardó un resultado de antes de invalidar"
+        );
+        assert!(
+            !RESOLVED
+                .read()
+                .expect("cerrojo envenenado")
+                .contains_key(inexistente)
+        );
+
+        // Con la generación al día, sí.
+        let al_dia = GENERACION.load(Ordering::SeqCst);
+        assert!(memorizar(inexistente, Some("nuevo".into()), al_dia));
+
+        invalidate_icon_cache();
     }
 }

--- a/src-tauri/src/window_manager/app_icon.rs
+++ b/src-tauri/src/window_manager/app_icon.rs
@@ -1,0 +1,330 @@
+//! El nombre del icono de una ventana, sacado de su archivo `.desktop`.
+//!
+//! El identificador que da el compositor (`app-id`) casi nunca es el nombre del
+//! icono. Antes se derivaba a mano quedándose con el último tramo después del
+//! punto, y eso rompía justo en los identificadores de tipo DNS invertido que
+//! son la norma: `org.telegram.desktop` daba `desktop`, que en el tema de
+//! iconos es la carpeta del escritorio, así que Telegram aparecía en el panel
+//! con un icono de carpeta —o sea, no aparecía—.
+//!
+//! Lo que corresponde es lo que hace cualquier barra de tareas: buscar la
+//! entrada `.desktop` de la aplicación y leer su clave `Icon`. Para
+//! `org.telegram.desktop` eso da `org.telegram.desktop`; para
+//! `com.anthropic.Claude`, `claude-desktop`.
+//!
+//! Buscar es barato: el `app-id` suele ser el nombre del archivo, así que se
+//! prueba `<dir>/<app-id>.desktop` directamente, sin recorrer nada. Sólo cuando
+//! eso no da con la entrada se recorren los directorios —por la caja del nombre
+//! o por `StartupWMClass`—, y el resultado, incluso el negativo, queda
+//! memorizado: cada `app-id` se resuelve una vez y no en cada evento del
+//! compositor, que con el panel abierto llegan de a decenas.
+
+use freedesktop_entry_parser::parse_entry;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{LazyLock, RwLock};
+
+use crate::menu_manager::applications_dirs;
+
+/// Icono para cuando no hay nada mejor que ofrecer.
+pub const FALLBACK_ICON: &str = "application-x-executable";
+
+/// `app-id` ya resuelto → nombre de icono. `None` es «se buscó y no está»,
+/// que también conviene recordar para no volver a recorrer los directorios.
+static RESOLVED: LazyLock<RwLock<HashMap<String, Option<String>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Techo de lo memorizado. La clave la elige el cliente —el `app-id` es lo que
+/// la aplicación quiera declarar—, así que sin esto crece hasta donde la dejen.
+/// Con más aplicaciones abiertas que esto, el escritorio tiene otro problema.
+const LIMITE_MEMORIZADO: usize = 512;
+
+/// Olvida lo resuelto. La llama el vigilante de `.desktop`: una aplicación
+/// recién instalada tiene que poder aparecer con su icono, y una que cambió el
+/// suyo tiene que dejar de mostrar el viejo.
+pub fn invalidate_icon_cache() {
+    if let Ok(mut cache) = RESOLVED.write() {
+        cache.clear();
+    }
+}
+
+/// El nombre de icono para un `app-id`, o `None` si no hay entrada `.desktop`
+/// que lo reclame.
+pub fn icon_for_app_id(app_id: &str) -> Option<String> {
+    let key = app_id.trim();
+    if key.is_empty() {
+        return None;
+    }
+
+    if let Ok(cache) = RESOLVED.read() {
+        if let Some(hit) = cache.get(key) {
+            return hit.clone();
+        }
+    }
+
+    let resolved = lookup_icon(key);
+
+    if let Ok(mut cache) = RESOLVED.write() {
+        if cache.len() >= LIMITE_MEMORIZADO {
+            cache.clear();
+        }
+        cache.insert(key.to_string(), resolved.clone());
+    }
+
+    resolved
+}
+
+/// La clave `Icon` de la entrada `.desktop` que corresponde a este `app-id`.
+fn lookup_icon(app_id: &str) -> Option<String> {
+    lookup_icon_in(app_id, &applications_dirs())
+}
+
+/// Lo mismo, sobre una lista de directorios dada. Separado para poder probarlo
+/// sin tocar el entorno del proceso.
+fn lookup_icon_in(app_id: &str, dirs: &[std::path::PathBuf]) -> Option<String> {
+    // Por nombre de archivo, que es el caso normal y no cuesta un escaneo.
+    // Se prueba tal cual y en minúsculas: `com.anthropic.Claude` viene con
+    // mayúsculas, otros identificadores llegan con la caja cambiada.
+    let lower = app_id.to_lowercase();
+    let mut stems = vec![app_id.to_string()];
+    if lower != app_id {
+        stems.push(lower);
+    }
+
+    for dir in dirs {
+        for stem in &stems {
+            let candidate = dir.join(format!("{stem}.desktop"));
+            if let Some(icon) = read_icon(&candidate) {
+                return Some(icon);
+            }
+        }
+    }
+
+    // Y si no, un recorrido: la caja del nombre del archivo puede no coincidir
+    // con la del `app-id`, y está `StartupWMClass`, que es la clave que existe
+    // justamente para atar una ventana a su entrada. Las dos cosas se resuelven
+    // en el mismo recorrido, que además se hace una sola vez por `app-id`
+    // porque el resultado queda memorizado.
+    for dir in dirs {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("desktop") {
+                continue;
+            }
+
+            let same_stem = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .is_some_and(|stem| stem.eq_ignore_ascii_case(app_id));
+
+            let parsed = match parse_entry(&path) {
+                Ok(parsed) => parsed,
+                Err(_) => continue,
+            };
+            let section = parsed.section("Desktop Entry");
+
+            let same_class = section
+                .attr("StartupWMClass")
+                .is_some_and(|class| class.eq_ignore_ascii_case(app_id));
+
+            if same_stem || same_class {
+                if let Some(icon) = non_empty(section.attr("Icon")) {
+                    return Some(icon);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// La clave `Icon` de un archivo, si el archivo existe y la tiene.
+fn read_icon(path: &Path) -> Option<String> {
+    let parsed = parse_entry(path).ok()?;
+    non_empty(parsed.section("Desktop Entry").attr("Icon"))
+}
+
+fn non_empty(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|icon| !icon.is_empty())
+        .map(str::to_string)
+}
+
+/// El `app-id` como nombre de icono, para cuando no hay entrada `.desktop`.
+///
+/// Sin recortes por el punto: muchos temas guardan el icono con el
+/// identificador completo (`org.telegram.desktop.png` está en *hicolor*), y
+/// quedarse con el último tramo convertía nombres válidos en otra cosa. Sólo se
+/// normaliza lo que no puede ser parte de un nombre de icono.
+pub fn fallback_icon_name(raw: &str) -> String {
+    let candidate = raw.trim();
+    if candidate.is_empty() {
+        return String::new();
+    }
+
+    candidate.replace(['_', ' '], "-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn escribir(dir: &Path, nombre: &str, cuerpo: &str) {
+        fs::write(dir.join(nombre), cuerpo).expect("no se pudo escribir la entrada");
+    }
+
+    /// Un directorio de aplicaciones de mentira, con las entradas que hacen
+    /// falta para las pruebas.
+    fn directorio_de_aplicaciones(etiqueta: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "vasak-app-icon-{}-{etiqueta}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("no se pudo crear el directorio");
+
+        escribir(
+            &dir,
+            "org.telegram.desktop.desktop",
+            "[Desktop Entry]\nName=Telegram\nIcon=org.telegram.desktop\nStartupWMClass=TelegramDesktop\n",
+        );
+        escribir(
+            &dir,
+            "com.anthropic.Claude.desktop",
+            "[Desktop Entry]\nName=Claude\nIcon=claude-desktop\n",
+        );
+        escribir(
+            &dir,
+            "editor.desktop",
+            "[Desktop Entry]\nName=Editor\nIcon=editor-icono\nStartupWMClass=EditorRaro\n",
+        );
+        escribir(
+            &dir,
+            "sin-icono.desktop",
+            "[Desktop Entry]\nName=Pelado\nIcon=\n",
+        );
+        escribir(&dir, "no-es-entrada.txt", "Icon=trampa\n");
+
+        dir
+    }
+
+    #[test]
+    fn el_nombre_de_reserva_no_recorta_por_el_punto() {
+        // La regresión: `org.telegram.desktop` daba `desktop`, que en el tema de
+        // iconos es la carpeta del escritorio, así que Telegram aparecía en el
+        // panel con un icono de carpeta —o sea, no aparecía—.
+        assert_eq!(
+            fallback_icon_name("org.telegram.desktop"),
+            "org.telegram.desktop"
+        );
+        assert_eq!(fallback_icon_name("google-chrome"), "google-chrome");
+        assert_eq!(fallback_icon_name(" vasak_terminal "), "vasak-terminal");
+        assert_eq!(fallback_icon_name("   "), "");
+    }
+
+    #[test]
+    fn el_icono_sale_de_la_entrada_desktop() {
+        let dir = directorio_de_aplicaciones("entrada");
+        let dirs = vec![dir.clone()];
+
+        // Por nombre de archivo, con el identificador completo: esto es lo que
+        // pone el icono de Telegram donde tiene que estar.
+        assert_eq!(
+            lookup_icon_in("org.telegram.desktop", &dirs).as_deref(),
+            Some("org.telegram.desktop")
+        );
+
+        // La caja del `app-id` no tiene por qué coincidir con la del archivo.
+        assert_eq!(
+            lookup_icon_in("com.anthropic.claude", &dirs).as_deref(),
+            Some("claude-desktop")
+        );
+        assert_eq!(
+            lookup_icon_in("com.anthropic.Claude", &dirs).as_deref(),
+            Some("claude-desktop")
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn el_icono_tambien_sale_por_startupwmclass() {
+        // Es la clave que existe justamente para atar una ventana a su entrada
+        // cuando el `app-id` no es el nombre del archivo.
+        let dir = directorio_de_aplicaciones("clase");
+        let dirs = vec![dir.clone()];
+
+        assert_eq!(
+            lookup_icon_in("editorraro", &dirs).as_deref(),
+            Some("editor-icono")
+        );
+        assert_eq!(
+            lookup_icon_in("EditorRaro", &dirs).as_deref(),
+            Some("editor-icono")
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn lo_que_no_tiene_entrada_no_resuelve() {
+        let dir = directorio_de_aplicaciones("sin-entrada");
+        let dirs = vec![dir.clone()];
+
+        // Una entrada sin icono no cuenta como encontrada: quien llama tiene un
+        // nombre de reserva mejor que la cadena vacía.
+        assert_eq!(lookup_icon_in("sin-icono", &dirs), None);
+        assert_eq!(lookup_icon_in("no.existe.nada", &dirs), None);
+        assert_eq!(lookup_icon_in("", &dirs), None);
+        // Un archivo que no es una entrada `.desktop` no se lee.
+        assert_eq!(lookup_icon_in("no-es-entrada", &dirs), None);
+        // Un directorio inexistente no rompe nada.
+        assert_eq!(
+            lookup_icon_in("org.telegram.desktop", &[PathBuf::from("/no/existe")]),
+            None
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn un_app_id_vacio_no_se_busca() {
+        assert_eq!(icon_for_app_id("   "), None);
+        assert_eq!(icon_for_app_id(""), None);
+    }
+
+    #[test]
+    fn lo_resuelto_queda_memorizado() {
+        // Incluye el resultado negativo: si no se guardara, cada evento del
+        // compositor volvería a recorrer todos los directorios de aplicaciones
+        // por cada ventana sin entrada.
+        let inexistente = "vasak.prueba.que.no.existe";
+        invalidate_icon_cache();
+
+        assert_eq!(icon_for_app_id(inexistente), None);
+        assert!(
+            RESOLVED
+                .read()
+                .expect("cerrojo envenenado")
+                .contains_key(inexistente),
+            "el resultado negativo no quedó memorizado"
+        );
+
+        invalidate_icon_cache();
+        assert!(
+            !RESOLVED
+                .read()
+                .expect("cerrojo envenenado")
+                .contains_key(inexistente),
+            "invalidar no vació lo memorizado"
+        );
+    }
+}

--- a/src-tauri/src/window_manager/fixtures/wayfire-list-views.json
+++ b/src-tauri/src/window_manager/fixtures/wayfire-list-views.json
@@ -50,7 +50,7 @@
   {
     "id": 16,
     "pid": 2639,
-    "title": "#alerta-xd-prod | Platform - Discord",
+    "title": "#general | Servidor de prueba - Discord",
     "app-id": "discord",
     "base-geometry": {
       "x": 358.0,
@@ -146,7 +146,7 @@
   {
     "id": 232,
     "pid": 3328,
-    "title": "‎⁨Programación y Dev⁩ – (35)",
+    "title": "‎⁨Grupo de prueba⁩ – (35)",
     "app-id": "org.telegram.desktop",
     "base-geometry": {
       "x": 551.0,
@@ -194,7 +194,7 @@
   {
     "id": 1757,
     "pid": 4767,
-    "title": "Recibidos - jdecima@pickit.net - Correo de Pickit - Google Chrome",
+    "title": "Recibidos - persona@example.com - Correo - Google Chrome",
     "app-id": "google-chrome",
     "base-geometry": {
       "x": 0.0,

--- a/src-tauri/src/window_manager/fixtures/wayfire-list-views.json
+++ b/src-tauri/src/window_manager/fixtures/wayfire-list-views.json
@@ -1,0 +1,482 @@
+[
+  {
+    "id": 3,
+    "pid": -1,
+    "title": "nil",
+    "app-id": "nil",
+    "base-geometry": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 0.0,
+      "height": 0.0
+    },
+    "parent": -1,
+    "geometry": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 0.0,
+      "height": 0.0
+    },
+    "bbox": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 0.0,
+      "height": 0.0
+    },
+    "output-id": 4294967295,
+    "output-name": "null",
+    "last-focus-timestamp": 0,
+    "role": "unmanaged",
+    "mapped": false,
+    "layer": "none",
+    "tiled-edges": 0,
+    "fullscreen": false,
+    "minimized": false,
+    "activated": false,
+    "sticky": false,
+    "wset-index": -1,
+    "min-size": {
+      "width": 0,
+      "height": 0
+    },
+    "max-size": {
+      "width": 0,
+      "height": 0
+    },
+    "focusable": true,
+    "type": "unmanaged",
+    "always-on-top": false
+  },
+  {
+    "id": 16,
+    "pid": 2639,
+    "title": "#alerta-xd-prod | Platform - Discord",
+    "app-id": "discord",
+    "base-geometry": {
+      "x": 358.0,
+      "y": 218.0,
+      "width": 1312.0,
+      "height": 762.0
+    },
+    "parent": -1,
+    "geometry": {
+      "x": 374.0,
+      "y": 228.0,
+      "width": 1280.0,
+      "height": 720.0
+    },
+    "bbox": {
+      "x": 358.0,
+      "y": 218.0,
+      "width": 1312.0,
+      "height": 762.0
+    },
+    "output-id": 1747,
+    "output-name": "HDMI-A-2",
+    "last-focus-timestamp": 147294918284446,
+    "role": "toplevel",
+    "mapped": true,
+    "layer": "workspace",
+    "tiled-edges": 0,
+    "fullscreen": false,
+    "minimized": false,
+    "activated": false,
+    "sticky": false,
+    "wset-index": 2,
+    "min-size": {
+      "width": 800,
+      "height": 500
+    },
+    "max-size": {
+      "width": 0,
+      "height": 0
+    },
+    "focusable": true,
+    "type": "toplevel",
+    "always-on-top": false
+  },
+  {
+    "id": 21,
+    "pid": 1268,
+    "title": "Claude",
+    "app-id": "com.anthropic.Claude",
+    "base-geometry": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 1920.0,
+      "height": 1080.0
+    },
+    "parent": -1,
+    "geometry": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 1920.0,
+      "height": 1080.0
+    },
+    "bbox": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 1920.0,
+      "height": 1080.0
+    },
+    "output-id": 1,
+    "output-name": "eDP-1",
+    "last-focus-timestamp": 147363968379810,
+    "role": "toplevel",
+    "mapped": true,
+    "layer": "workspace",
+    "tiled-edges": 15,
+    "fullscreen": false,
+    "minimized": false,
+    "activated": false,
+    "sticky": false,
+    "wset-index": 1,
+    "min-size": {
+      "width": 632,
+      "height": 442
+    },
+    "max-size": {
+      "width": 0,
+      "height": 0
+    },
+    "focusable": true,
+    "type": "toplevel",
+    "always-on-top": false
+  },
+  {
+    "id": 232,
+    "pid": 3328,
+    "title": "‎⁨Programación y Dev⁩ – (35)",
+    "app-id": "org.telegram.desktop",
+    "base-geometry": {
+      "x": 551.0,
+      "y": 239.0,
+      "width": 818.0,
+      "height": 642.0
+    },
+    "parent": -1,
+    "geometry": {
+      "x": 560.0,
+      "y": 247.0,
+      "width": 800.0,
+      "height": 624.0
+    },
+    "bbox": {
+      "x": 551.0,
+      "y": 239.0,
+      "width": 818.0,
+      "height": 642.0
+    },
+    "output-id": 1,
+    "output-name": "eDP-1",
+    "last-focus-timestamp": 146459369383651,
+    "role": "toplevel",
+    "mapped": true,
+    "layer": "workspace",
+    "tiled-edges": 0,
+    "fullscreen": false,
+    "minimized": false,
+    "activated": false,
+    "sticky": false,
+    "wset-index": 1,
+    "min-size": {
+      "width": 380,
+      "height": 504
+    },
+    "max-size": {
+      "width": 16777197,
+      "height": 16777197
+    },
+    "focusable": true,
+    "type": "toplevel",
+    "always-on-top": false
+  },
+  {
+    "id": 1757,
+    "pid": 4767,
+    "title": "Recibidos - jdecima@pickit.net - Correo de Pickit - Google Chrome",
+    "app-id": "google-chrome",
+    "base-geometry": {
+      "x": 0.0,
+      "y": 38.0,
+      "width": 1920.0,
+      "height": 1042.0
+    },
+    "parent": -1,
+    "geometry": {
+      "x": 0.0,
+      "y": 38.0,
+      "width": 1920.0,
+      "height": 1042.0
+    },
+    "bbox": {
+      "x": 0.0,
+      "y": 38.0,
+      "width": 1920.0,
+      "height": 1042.0
+    },
+    "output-id": 1747,
+    "output-name": "HDMI-A-2",
+    "last-focus-timestamp": 146622443702589,
+    "role": "toplevel",
+    "mapped": true,
+    "layer": "workspace",
+    "tiled-edges": 15,
+    "fullscreen": false,
+    "minimized": true,
+    "activated": false,
+    "sticky": false,
+    "wset-index": 2,
+    "min-size": {
+      "width": 520,
+      "height": 141
+    },
+    "max-size": {
+      "width": 0,
+      "height": 0
+    },
+    "focusable": true,
+    "type": "toplevel",
+    "always-on-top": false
+  },
+  {
+    "id": 2066,
+    "pid": 685041,
+    "title": "Vasak Terminal",
+    "app-id": "vasak-terminal",
+    "base-geometry": {
+      "x": 0.0,
+      "y": 38.0,
+      "width": 1920.0,
+      "height": 1042.0
+    },
+    "parent": -1,
+    "geometry": {
+      "x": 0.0,
+      "y": 38.0,
+      "width": 1920.0,
+      "height": 1042.0
+    },
+    "bbox": {
+      "x": 0.0,
+      "y": 38.0,
+      "width": 1920.0,
+      "height": 1042.0
+    },
+    "output-id": 1747,
+    "output-name": "HDMI-A-2",
+    "last-focus-timestamp": 145940090996603,
+    "role": "toplevel",
+    "mapped": true,
+    "layer": "workspace",
+    "tiled-edges": 15,
+    "fullscreen": false,
+    "minimized": true,
+    "activated": false,
+    "sticky": false,
+    "wset-index": 2,
+    "min-size": {
+      "width": 0,
+      "height": 0
+    },
+    "max-size": {
+      "width": 0,
+      "height": 0
+    },
+    "focusable": true,
+    "type": "toplevel",
+    "always-on-top": false
+  },
+  {
+    "id": 2196,
+    "pid": 392036,
+    "title": "layer-shell",
+    "app-id": "vasak-flare",
+    "base-geometry": {
+      "x": 1528.0,
+      "y": 948.0,
+      "width": 380.0,
+      "height": 120.0
+    },
+    "parent": -1,
+    "geometry": {
+      "x": 1528.0,
+      "y": 948.0,
+      "width": 380.0,
+      "height": 120.0
+    },
+    "bbox": {
+      "x": 1528.0,
+      "y": 948.0,
+      "width": 380.0,
+      "height": 120.0
+    },
+    "output-id": 1,
+    "output-name": "eDP-1",
+    "last-focus-timestamp": 0,
+    "role": "desktop-environment",
+    "mapped": true,
+    "layer": "overlay",
+    "tiled-edges": 0,
+    "fullscreen": false,
+    "minimized": false,
+    "activated": false,
+    "sticky": false,
+    "wset-index": -1,
+    "min-size": {
+      "width": 0,
+      "height": 0
+    },
+    "max-size": {
+      "width": 0,
+      "height": 0
+    },
+    "focusable": true,
+    "type": "overlay",
+    "always-on-top": false
+  },
+  {
+    "id": 2227,
+    "pid": 712722,
+    "title": "layer-shell",
+    "app-id": "vasak-desktop",
+    "base-geometry": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 1920.0,
+      "height": 1080.0
+    },
+    "parent": -1,
+    "geometry": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 1920.0,
+      "height": 1080.0
+    },
+    "bbox": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 1920.0,
+      "height": 1080.0
+    },
+    "output-id": 1,
+    "output-name": "eDP-1",
+    "last-focus-timestamp": 0,
+    "role": "desktop-environment",
+    "mapped": true,
+    "layer": "background",
+    "tiled-edges": 0,
+    "fullscreen": false,
+    "minimized": false,
+    "activated": false,
+    "sticky": false,
+    "wset-index": -1,
+    "min-size": {
+      "width": 0,
+      "height": 0
+    },
+    "max-size": {
+      "width": 0,
+      "height": 0
+    },
+    "focusable": true,
+    "type": "background",
+    "always-on-top": false
+  },
+  {
+    "id": 2229,
+    "pid": 712722,
+    "title": "layer-shell",
+    "app-id": "vasak-panel",
+    "base-geometry": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 1920.0,
+      "height": 38.0
+    },
+    "parent": -1,
+    "geometry": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 1920.0,
+      "height": 38.0
+    },
+    "bbox": {
+      "x": 0.0,
+      "y": 0.0,
+      "width": 1920.0,
+      "height": 38.0
+    },
+    "output-id": 1747,
+    "output-name": "HDMI-A-2",
+    "last-focus-timestamp": 0,
+    "role": "desktop-environment",
+    "mapped": true,
+    "layer": "top",
+    "tiled-edges": 0,
+    "fullscreen": false,
+    "minimized": false,
+    "activated": false,
+    "sticky": false,
+    "wset-index": -1,
+    "min-size": {
+      "width": 0,
+      "height": 0
+    },
+    "max-size": {
+      "width": 0,
+      "height": 0
+    },
+    "focusable": true,
+    "type": "panel",
+    "always-on-top": false
+  },
+  {
+    "id": 2231,
+    "pid": 712722,
+    "title": "",
+    "app-id": "vasak-desktop",
+    "base-geometry": {
+      "x": 850.0,
+      "y": 440.0,
+      "width": 220.0,
+      "height": 200.0
+    },
+    "parent": -1,
+    "geometry": {
+      "x": 850.0,
+      "y": 440.0,
+      "width": 220.0,
+      "height": 200.0
+    },
+    "bbox": {
+      "x": 850.0,
+      "y": 440.0,
+      "width": 220.0,
+      "height": 200.0
+    },
+    "output-id": 1,
+    "output-name": "eDP-1",
+    "last-focus-timestamp": 147914630206481,
+    "role": "toplevel",
+    "mapped": true,
+    "layer": "workspace",
+    "tiled-edges": 0,
+    "fullscreen": false,
+    "minimized": false,
+    "activated": true,
+    "sticky": false,
+    "wset-index": 1,
+    "min-size": {
+      "width": 220,
+      "height": 200
+    },
+    "max-size": {
+      "width": 220,
+      "height": 200
+    },
+    "focusable": true,
+    "type": "toplevel",
+    "always-on-top": false
+  }
+]

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -1,3 +1,4 @@
+pub mod app_icon;
 pub mod delta;
 pub mod wayland;
 pub mod wayfire_ipc;

--- a/src-tauri/src/window_manager/wayland.rs
+++ b/src-tauri/src/window_manager/wayland.rs
@@ -312,7 +312,10 @@ mod tests {
         // Sin entrada `.desktop` a mano, el nombre de reserva tiene que ser el
         // `app-id` completo: recortarlo daba `desktop` para Telegram, que en el
         // tema de iconos es la carpeta del escritorio.
-        app_icon::invalidate_icon_cache();
+        //
+        // El `app-id` es propio de esta prueba, así que no hace falta vaciar lo
+        // memorizado —y no conviene: es global, y las pruebas corren en
+        // paralelo—.
         let telegram = aplicacion(232, "no.instalado.telegram", "Programación y Dev");
         let ventana = WaylandManager::view_to_window_info(&telegram).expect("debería listarse");
         assert_eq!(ventana.icon, "no.instalado.telegram");

--- a/src-tauri/src/window_manager/wayland.rs
+++ b/src-tauri/src/window_manager/wayland.rs
@@ -1,3 +1,4 @@
+use super::app_icon;
 use super::{wayfire_ipc::{get_wayfire_client, View}, WindowInfo, WindowManagerBackend};
 use std::sync::mpsc::Sender;
 
@@ -21,20 +22,55 @@ impl WaylandManager {
         }
     }
 
-    fn normalize_icon_name(raw: &str) -> String {
-        let candidate = raw.trim().to_lowercase();
-        if candidate.is_empty() {
-            return String::new();
-        }
-
-        let tail = candidate.rsplit('.').next().unwrap_or(&candidate);
-        tail.replace(['_', ' '], "-")
+    /// Wayfire manda el texto `nil` cuando el cliente no dio el dato.
+    fn field(value: Option<&str>) -> Option<&str> {
+        value
+            .map(str::trim)
+            .filter(|value| !value.is_empty() && *value != "nil")
     }
+
+    /// Sólo las ventanas de aplicación van al panel.
+    ///
+    /// Wayfire le pone `role` a cada superficie, y el que corresponde a una
+    /// ventana de aplicación es `toplevel`: las superficies del propio
+    /// escritorio —el panel, el fondo, el centro de control, los carteles de
+    /// notificación— llegan como `desktop-environment`, y los menús y globos
+    /// como `unmanaged`. Antes se decidía por el campo `type`, y esa lista no
+    /// incluía `overlay`, que es lo que declara una superficie en la capa
+    /// *overlay*: por eso cada notificación de vasak-flare aparecía en el panel
+    /// como una aplicación abierta, con título «layer-shell».
+    fn is_application_window(view: &View) -> bool {
+        match Self::field(view.role.as_deref()) {
+            Some(role) => role.eq_ignore_ascii_case("toplevel"),
+            // Sin rol no se puede decidir por acá; deciden los demás filtros.
+            None => true,
+        }
+    }
+
+    /// Los espacios de nombres con que el escritorio declara sus superficies de
+    /// capa —el `namespace` que se le pasa a `gtk-layer-shell`—, y con los que
+    /// llegan como `app-id`.
+    ///
+    /// Es una lista exacta y no un prefijo `vasak-`: vasak-terminal,
+    /// vasak-settings o vasak-file-manager son aplicaciones como cualquier otra
+    /// y tienen que verse en el panel.
+    const SHELL_NAMESPACES: [&'static str; 5] = [
+        "vasak",
+        "vasak-panel",
+        "vasak-desktop",
+        "vasak-control-center",
+        "vasak-flare",
+    ];
 
     fn is_shell_window(view: &View) -> bool {
-        view.app_id.as_deref() == Some("vasak-desktop")
+        matches!(
+            Self::field(view.app_id.as_deref()),
+            Some(app_id) if Self::SHELL_NAMESPACES.contains(&app_id)
+        )
     }
 
+    /// Red de seguridad para cuando no llega `role`: las superficies de capa se
+    /// reconocen por el `type` que Wayfire deriva de su capa.
     fn is_layer_shell_window(view: &View) -> bool {
         if Self::is_shell_window(view) {
             return true;
@@ -47,9 +83,29 @@ impl WaylandManager {
                 let lower = value.to_lowercase();
                 matches!(
                     lower.as_str(),
-                    "panel" | "desktop" | "dock" | "layer-shell" | "layershell"
+                    "panel"
+                        | "desktop"
+                        | "dock"
+                        | "background"
+                        | "bottom"
+                        | "top"
+                        | "overlay"
+                        | "layer-shell"
+                        | "layershell"
                 ) || lower.contains("layer-shell")
             })
+    }
+
+    /// El nombre del icono: la clave `Icon` de la entrada `.desktop` de la
+    /// aplicación, y si no hay entrada, el `app-id` tal cual.
+    fn icon_name(view: &View) -> String {
+        Self::field(view.app_id.as_deref())
+            .and_then(|app_id| {
+                app_icon::icon_for_app_id(app_id)
+                    .or_else(|| Some(app_icon::fallback_icon_name(app_id)))
+            })
+            .filter(|icon| !icon.is_empty())
+            .unwrap_or_else(|| app_icon::FALLBACK_ICON.to_string())
     }
 
     fn view_to_window_info(view: &View) -> Option<WindowInfo> {
@@ -66,25 +122,18 @@ impl WaylandManager {
             return None;
         }
 
+        if !Self::is_application_window(view) {
+            return None;
+        }
+
         if Self::is_layer_shell_window(view) {
             return None;
         }
 
-        let title = view.title.clone().unwrap_or_default();
-        let icon = view
-            .app_id
-            .as_deref()
-            .map(Self::normalize_icon_name)
-            .filter(|icon| !icon.is_empty())
-            .or_else(|| {
-                view.role
-                    .as_deref()
-                    .map(Self::normalize_icon_name)
-                    .filter(|icon| !icon.is_empty())
-            })
-            .unwrap_or_else(|| "application-x-executable".to_string());
+        let title = Self::field(view.title.as_deref()).unwrap_or_default().to_string();
+        let icon = Self::icon_name(view);
 
-        if title.is_empty() && icon == "application-x-executable" {
+        if title.is_empty() && icon == app_icon::FALLBACK_ICON {
             return None;
         }
 
@@ -171,5 +220,218 @@ impl WindowManagerBackend for WaylandManager {
 impl Default for WaylandManager {
     fn default() -> Self {
         Self::new().expect("Failed to initialize WaylandManager")
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Una vista como las que manda Wayfire, con lo mínimo para decidir.
+    fn vista(id: i64, app_id: &str, title: &str, role: &str, type_field: &str, layer: &str) -> View {
+        View {
+            activated: false,
+            app_id: Some(app_id.to_string()),
+            base_geometry: None,
+            bbox: None,
+            focusable: Some(true),
+            fullscreen: Some(false),
+            geometry: None,
+            id,
+            last_focus_timestamp: None,
+            layer: Some(layer.to_string()),
+            mapped: Some(true),
+            max_size: None,
+            min_size: None,
+            minimized: Some(false),
+            output_id: None,
+            output_name: None,
+            parent: None,
+            pid: None,
+            role: Some(role.to_string()),
+            sticky: Some(false),
+            tiled_edges: None,
+            title: Some(title.to_string()),
+            type_field: Some(type_field.to_string()),
+            wset_index: None,
+        }
+    }
+
+    fn aplicacion(id: i64, app_id: &str, title: &str) -> View {
+        vista(id, app_id, title, "toplevel", "toplevel", "workspace")
+    }
+
+    #[test]
+    fn un_cartel_de_notificacion_no_es_una_aplicacion_abierta() {
+        // La regresión: el cartel de vasak-flare vive en la capa *overlay*, y
+        // el filtro por `type` no conocía ese valor, así que cada notificación
+        // se sumaba al panel como una aplicación abierta llamada «layer-shell».
+        let cartel = vista(
+            2196,
+            "vasak-flare",
+            "layer-shell",
+            "desktop-environment",
+            "overlay",
+            "overlay",
+        );
+        assert_eq!(WaylandManager::view_to_window_info(&cartel), None);
+    }
+
+    #[test]
+    fn ninguna_superficie_del_escritorio_va_al_panel() {
+        let superficies = [
+            vista(1749, "vasak-desktop", "layer-shell", "desktop-environment", "background", "background"),
+            vista(1751, "vasak-panel", "layer-shell", "desktop-environment", "panel", "top"),
+            vista(1800, "vasak", "layer-shell", "desktop-environment", "panel", "top"),
+            vista(1801, "vasak-control-center", "layer-shell", "desktop-environment", "overlay", "overlay"),
+            vista(3, "nil", "nil", "unmanaged", "unmanaged", "none"),
+        ];
+
+        for superficie in &superficies {
+            assert_eq!(
+                WaylandManager::view_to_window_info(superficie),
+                None,
+                "{:?} llegó al panel",
+                superficie.app_id
+            );
+        }
+    }
+
+    #[test]
+    fn las_aplicaciones_del_sistema_si_van_al_panel() {
+        // El otro lado del filtro anterior: que se descarten las superficies
+        // del escritorio no puede llevarse puestas las aplicaciones propias,
+        // que comparten el prefijo del nombre.
+        for app_id in ["vasak-terminal", "vasak-settings", "vasak-file-manager"] {
+            let ventana = WaylandManager::view_to_window_info(&aplicacion(2066, app_id, "Título"));
+            assert!(ventana.is_some(), "{app_id} no llegó al panel");
+        }
+    }
+
+    #[test]
+    fn el_icono_no_se_recorta_por_el_punto() {
+        // Sin entrada `.desktop` a mano, el nombre de reserva tiene que ser el
+        // `app-id` completo: recortarlo daba `desktop` para Telegram, que en el
+        // tema de iconos es la carpeta del escritorio.
+        app_icon::invalidate_icon_cache();
+        let telegram = aplicacion(232, "no.instalado.telegram", "Programación y Dev");
+        let ventana = WaylandManager::view_to_window_info(&telegram).expect("debería listarse");
+        assert_eq!(ventana.icon, "no.instalado.telegram");
+        assert_eq!(ventana.id, "232");
+        assert_eq!(ventana.title, "Programación y Dev");
+    }
+
+    #[test]
+    fn una_ventana_sin_datos_no_se_lista() {
+        // `nil` es lo que manda Wayfire cuando el cliente no dio el dato, y no
+        // un título ni un nombre de icono.
+        let vacia = aplicacion(10, "nil", "nil");
+        assert_eq!(WaylandManager::view_to_window_info(&vacia), None);
+    }
+
+    #[test]
+    fn una_ventana_sin_mapear_o_sin_foco_no_se_lista() {
+        let mut sin_mapear = aplicacion(11, "discord", "Discord");
+        sin_mapear.mapped = Some(false);
+        assert_eq!(WaylandManager::view_to_window_info(&sin_mapear), None);
+
+        let mut sin_foco = aplicacion(12, "discord", "Discord");
+        sin_foco.focusable = Some(false);
+        assert_eq!(WaylandManager::view_to_window_info(&sin_foco), None);
+    }
+
+    #[test]
+    fn una_ventana_minimizada_se_lista_como_tal() {
+        let mut minimizada = aplicacion(16, "discord", "Discord");
+        minimizada.minimized = Some(true);
+        let ventana = WaylandManager::view_to_window_info(&minimizada).expect("debería listarse");
+        assert!(ventana.is_minimized);
+    }
+}
+
+/// Sobre una respuesta real de `window-rules/list-views`, capturada de esta
+/// sesión con el panel mostrando de más y de menos.
+#[cfg(test)]
+mod pruebas_con_captura_real {
+    use super::*;
+
+    /// Lo que devolvió el compositor el día que se arregló esto: un cartel de
+    /// notificación en la capa *overlay*, las superficies del escritorio, una
+    /// ventana suelta de vasak-desktop y las aplicaciones de verdad.
+    const CAPTURA: &str = include_str!("fixtures/wayfire-list-views.json");
+
+    fn ventanas() -> Vec<WindowInfo> {
+        let views: Vec<View> =
+            serde_json::from_str(CAPTURA).expect("la captura del compositor tiene que parsear");
+        views
+            .iter()
+            .filter_map(WaylandManager::view_to_window_info)
+            .collect()
+    }
+
+    #[test]
+    fn el_panel_lista_las_aplicaciones_y_nada_mas() {
+        let ventanas = ventanas();
+        let ids: Vec<&str> = ventanas.iter().map(|w| w.id.as_str()).collect();
+
+        // Discord, Claude, Telegram, Chrome y la terminal.
+        assert_eq!(ids, vec!["16", "21", "232", "1757", "2066"]);
+    }
+
+    #[test]
+    fn telegram_esta_y_con_su_icono() {
+        let telegram = ventanas()
+            .into_iter()
+            .find(|w| w.id == "232")
+            .expect("Telegram tiene que estar en el panel");
+
+        // `desktop` era lo que salía de recortar `org.telegram.desktop` por el
+        // punto, y en el tema de iconos es la carpeta del escritorio.
+        assert_ne!(telegram.icon, "desktop");
+        assert!(
+            telegram.icon.contains("telegram"),
+            "icono inesperado: {}",
+            telegram.icon
+        );
+    }
+}
+
+/// Contra el compositor de verdad, con la sesión andando. Se corre a mano
+/// —`cargo test -- --ignored ventanas_de_la_sesion`— porque necesita un Wayfire
+/// con su socket de IPC, que en una máquina de integración no está.
+///
+/// Sirve para lo que ninguna captura fija puede: ver qué recibe el panel ahora
+/// mismo, con las aplicaciones que estén abiertas y con un cartel de
+/// notificación en pantalla.
+#[cfg(test)]
+mod prueba_en_vivo {
+    use super::*;
+
+    #[ignore = "necesita una sesión de Wayfire andando"]
+    #[tokio::test]
+    async fn ventanas_de_la_sesion() {
+        let client = get_wayfire_client()
+            .await
+            .expect("sin socket de Wayfire no hay nada que probar");
+        let views = client.list_views_typed().await.expect("list-views falló");
+
+        let ventanas: Vec<WindowInfo> = views
+            .iter()
+            .filter_map(WaylandManager::view_to_window_info)
+            .collect();
+
+        for ventana in &ventanas {
+            println!("{} · icono {} · {}", ventana.id, ventana.icon, ventana.title);
+        }
+
+        // Ninguna superficie del escritorio: ni el panel, ni el fondo, ni los
+        // carteles de notificación.
+        for ventana in &ventanas {
+            assert_ne!(ventana.title, "layer-shell", "una superficie de capa llegó al panel");
+        }
+
+        // Y ningún icono adivinado por el último tramo del identificador.
+        for ventana in &ventanas {
+            assert_ne!(ventana.icon, "desktop", "{} quedó con el icono de la carpeta", ventana.title);
+        }
     }
 }


### PR DESCRIPTION
En las aplicaciones abiertas del panel faltaba Telegram y sobraban las notificaciones. Eran dos fallas distintas con el mismo síntoma.

## Telegram aparecía como una carpeta

El nombre del icono se adivinaba recortando el `app-id` por el último punto, así que `org.telegram.desktop` daba `desktop` — que en el tema de iconos es la carpeta del escritorio. Telegram sí estaba en la lista, pero con un icono de carpeta celeste, o sea: no estaba.

Ahora el nombre sale de la clave `Icon` de la entrada `.desktop` de la aplicación, que es donde está escrito y es lo que hace cualquier barra de tareas: `org.telegram.desktop` para Telegram, `claude-desktop` para Claude, `terminal` para vasak-terminal. La búsqueda prueba primero `<dir>/<app-id>.desktop`, que es el caso normal y no cuesta un escaneo, y sólo recorre los directorios —por la caja del nombre o por `StartupWMClass`— cuando eso no alcanza. Lo resuelto queda memorizado con techo, y lo invalida el mismo vigilante que ya refrescaba el menú cuando cambia un `.desktop`.

## Cada notificación ocupaba un lugar en el panel

El cartel de vasak-flare es una superficie *layer-shell* en la capa `overlay`. El filtro de superficies del escritorio decidía por el campo `type`, y esa lista tenía `panel|desktop|dock|layer-shell` pero no `overlay`: cada notificación entraba a la lista como una aplicación abierta llamada «layer-shell».

Ahora se descarta por el `role` que da el compositor, que es `desktop-environment` para todas las superficies del escritorio —panel, fondo, centro de control, carteles— y `unmanaged` para menús y globos. Cubre las que vengan, sin lista que mantener. El filtro por espacios de nombres pasó a ser una lista exacta y no el prefijo `vasak-`, para que vasak-terminal o vasak-settings no se vayan con él.

## Verificación

Con el binario compilado y el escritorio levantado en una sesión real, con un cartel de notificación en pantalla, el panel recibe:

```
16   · icono discord              · Discord
21   · icono claude-desktop       · Claude
232  · icono org.telegram.desktop · Programación y Dev – (43)
2066 · icono terminal             · Vasak Terminal
2072 · icono kiro                 · Kiro
```

Telegram con su icono real y ningún «layer-shell» en la lista.

## Tests

No había ninguno para el filtrado ni para la resolución de icono; quedan 30 en `window_manager`:

- Casos armados: cada superficie del escritorio descartada, las aplicaciones propias no, el icono sin recortar, `nil` tratado como dato ausente, minimizada, sin mapear, sin foco.
- Una respuesta real de `window-rules/list-views` capturada de la sesión donde se vio la falla, como fixture: el panel lista las cinco aplicaciones y nada más.
- Una prueba contra el compositor en vivo, ignorada por defecto (`cargo test -- --ignored ventanas_de_la_sesion`), que imprime lo que recibe el panel ahora mismo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Applications now display their actual desktop icons when available, including newly installed apps.
  - Improved icon matching supports varied application identifiers and desktop-entry names.
  - Window detection now better recognizes application windows, overlays, panels, and shell elements.

- **Bug Fixes**
  - Prevented fallback identifiers from appearing in place of application icons.
  - Improved handling of missing or incomplete window metadata for more reliable filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->