### PR TITLE
fix: las aplicaciones se abren desde el hogar, no desde el directorio del escritorio

### DIFF
--- a/src-tauri/src/commands/runner.rs
+++ b/src-tauri/src/commands/runner.rs
@@ -1,7 +1,27 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
 use std::process::Command;
 use crate::logger::{log_info, log_error};
+
+/// El directorio desde el que arranca una aplicación que abre el escritorio.
+///
+/// Tiene que ser el hogar y no el que herede el proceso del escritorio. Un
+/// proceso hijo hereda el directorio de trabajo del padre, y el del escritorio
+/// es el que haya tenido quien lo lanzó: con la sesión normal es el hogar, pero
+/// arrancado a mano desde el árbol de fuentes de una aplicación Tauri —cosa que
+/// se hace todo el tiempo para probar— es un directorio con un `locales/`
+/// adentro.
+///
+/// Y eso rompe a la aplicación que se abra: el plugin de idiomas busca los
+/// catálogos primero en `<directorio actual>/locales`, así que **cualquier**
+/// aplicación abierta desde el menú cargaba los textos del escritorio en lugar
+/// de los suyos y mostraba las claves crudas —`app.titulo`, `recursos.cpu`— en
+/// vez de la interfaz traducida. El mismo binario, abierto desde otro lado,
+/// andaba perfecto.
+fn directorio_de_arranque() -> PathBuf {
+    dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"))
+}
 
 fn parse_exec_line(exec_line: &str) -> Result<(String, Vec<String>), String> {
     let parts = shlex::split(exec_line).ok_or_else(|| "No se pudo parsear Exec".to_string())?;
@@ -40,10 +60,14 @@ pub async fn open_app(path: &str) -> Result<(), String> {
             })?;
 
             log_info(&format!("Ejecutando comando: {} {:?}", cmd, args));
-            Command::new(&cmd).args(&args).spawn().map_err(|e| {
-                log_error(&format!("Error al ejecutar comando {} {:?}: {}", cmd, args, e));
-                e.to_string()
-            })?;
+            Command::new(&cmd)
+                .args(&args)
+                .current_dir(directorio_de_arranque())
+                .spawn()
+                .map_err(|e| {
+                    log_error(&format!("Error al ejecutar comando {} {:?}: {}", cmd, args, e));
+                    e.to_string()
+                })?;
 
             return Ok(());
         }
@@ -77,6 +101,7 @@ pub fn spawn_settings_at(seccion: Option<&str>) -> Result<(), String> {
     log_info("Abriendo la aplicación de configuración");
 
     let mut comando = Command::new(SETTINGS_BINARY);
+    comando.current_dir(directorio_de_arranque());
 
     if let Some(seccion) = seccion.filter(|valor| es_nombre_de_seccion(valor)) {
         comando.arg(seccion);
@@ -119,6 +144,31 @@ fn es_nombre_de_seccion(valor: &str) -> bool {
         && valor
             .chars()
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+#[cfg(test)]
+mod tests_arranque {
+    use super::directorio_de_arranque;
+
+    #[test]
+    fn es_un_directorio_que_existe_y_no_el_del_escritorio() {
+        // Lo que importa no es cuál sea, sino que sea uno elegido y no el que el
+        // escritorio haya heredado: desde el árbol de fuentes de una aplicación
+        // Tauri, el directorio actual tiene un `locales/` que la aplicación
+        // abierta cargaba en lugar de los suyos.
+        let directorio = directorio_de_arranque();
+        assert!(directorio.is_absolute(), "{directorio:?}");
+        assert!(directorio.is_dir(), "{directorio:?}");
+
+        if let Ok(actual) = std::env::current_dir() {
+            if actual.join("locales").is_dir() {
+                assert_ne!(
+                    directorio, actual,
+                    "se estaría entregando un directorio con catálogos de otra aplicación"
+                );
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/runner.rs
+++ b/src-tauri/src/commands/runner.rs
@@ -23,6 +23,16 @@ fn directorio_de_arranque() -> PathBuf {
     dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"))
 }
 
+/// El comando con el que se abre una aplicación, ya con su directorio puesto.
+///
+/// Existe para que la regla —«toda aplicación que abre el escritorio arranca
+/// desde un directorio elegido»— se pueda comprobar sin ejecutar nada.
+fn comando_de_aplicacion(programa: &str, argumentos: &[String]) -> Command {
+    let mut comando = Command::new(programa);
+    comando.args(argumentos).current_dir(directorio_de_arranque());
+    comando
+}
+
 fn parse_exec_line(exec_line: &str) -> Result<(String, Vec<String>), String> {
     let parts = shlex::split(exec_line).ok_or_else(|| "No se pudo parsear Exec".to_string())?;
 
@@ -60,14 +70,10 @@ pub async fn open_app(path: &str) -> Result<(), String> {
             })?;
 
             log_info(&format!("Ejecutando comando: {} {:?}", cmd, args));
-            Command::new(&cmd)
-                .args(&args)
-                .current_dir(directorio_de_arranque())
-                .spawn()
-                .map_err(|e| {
-                    log_error(&format!("Error al ejecutar comando {} {:?}: {}", cmd, args, e));
-                    e.to_string()
-                })?;
+            comando_de_aplicacion(&cmd, &args).spawn().map_err(|e| {
+                log_error(&format!("Error al ejecutar comando {} {:?}: {}", cmd, args, e));
+                e.to_string()
+            })?;
 
             return Ok(());
         }
@@ -100,8 +106,7 @@ pub fn spawn_settings() -> Result<(), String> {
 pub fn spawn_settings_at(seccion: Option<&str>) -> Result<(), String> {
     log_info("Abriendo la aplicación de configuración");
 
-    let mut comando = Command::new(SETTINGS_BINARY);
-    comando.current_dir(directorio_de_arranque());
+    let mut comando = comando_de_aplicacion(SETTINGS_BINARY, &[]);
 
     if let Some(seccion) = seccion.filter(|valor| es_nombre_de_seccion(valor)) {
         comando.arg(seccion);
@@ -148,25 +153,33 @@ fn es_nombre_de_seccion(valor: &str) -> bool {
 
 #[cfg(test)]
 mod tests_arranque {
-    use super::directorio_de_arranque;
+    use super::{comando_de_aplicacion, directorio_de_arranque};
 
     #[test]
-    fn es_un_directorio_que_existe_y_no_el_del_escritorio() {
-        // Lo que importa no es cuál sea, sino que sea uno elegido y no el que el
-        // escritorio haya heredado: desde el árbol de fuentes de una aplicación
-        // Tauri, el directorio actual tiene un `locales/` que la aplicación
-        // abierta cargaba en lugar de los suyos.
-        let directorio = directorio_de_arranque();
+    fn toda_aplicacion_arranca_con_un_directorio_puesto() {
+        // La regresión: sin `current_dir`, el hijo hereda el del escritorio, y
+        // desde el árbol de fuentes de una aplicación Tauri ése tiene un
+        // `locales/` que la aplicación abierta cargaba en lugar de los suyos.
+        //
+        // Se comprueba sobre el comando ya armado y no sobre el entorno de la
+        // prueba: mirar si el directorio actual tiene un `locales/` haría que en
+        // otra máquina la prueba pasara sin comprobar nada.
+        let comando = comando_de_aplicacion("cualquiera", &["argumento".to_string()]);
+
+        let directorio = comando
+            .get_current_dir()
+            .expect("la aplicación tiene que arrancar con un directorio puesto");
+        assert_eq!(directorio, directorio_de_arranque());
         assert!(directorio.is_absolute(), "{directorio:?}");
         assert!(directorio.is_dir(), "{directorio:?}");
+    }
 
-        if let Ok(actual) = std::env::current_dir() {
-            if actual.join("locales").is_dir() {
-                assert_ne!(
-                    directorio, actual,
-                    "se estaría entregando un directorio con catálogos de otra aplicación"
-                );
-            }
+    #[test]
+    fn el_directorio_de_arranque_es_el_hogar() {
+        // Y no la raíz, salvo que no haya hogar: es el directorio desde el que
+        // cualquier lanzador de escritorio abre una aplicación.
+        if let Some(hogar) = dirs::home_dir() {
+            assert_eq!(directorio_de_arranque(), hogar);
         }
     }
 }


### PR DESCRIPTION
Las aplicaciones abiertas desde el menú mostraban **las claves crudas** en vez de los textos: `app.titulo`, `pantallas.recursos`, `recursos.cpu`, `ajustes.intervalo`. Pasaba con el monitor, con las capturas y con la configuración; el mismo binario abierto desde una terminal andaba perfecto.

## La causa

Un proceso hijo hereda el directorio de trabajo del padre. `open_app` y `spawn_settings` usan `Command::spawn()` sin fijar ninguno, así que le entregaban a cada aplicación el del escritorio — que es el que haya tenido quien lo lanzó.

Con la sesión normal eso es el hogar y no se nota. Arrancado a mano desde el árbol de fuentes de una aplicación Tauri —cosa que se hace todo el tiempo para probar— es un directorio con un `locales/` adentro, y el plugin de idiomas busca ahí antes que en `/usr/share`: la aplicación cargaba los catálogos **del escritorio** y no reconocía ninguna de sus claves.

Reproducido: `cd vasak-desktop/src-tauri && /usr/bin/vasak-monitor` muestra la interfaz en crudo; el mismo binario desde `$HOME`, en español.

## El arreglo

El escritorio no tiene por qué imponerle su directorio a lo que abre: le corresponde el hogar, como a cualquier lanzador. El plugin se arregla por su lado en [tauri-plugin-i18n#6](https://github.com/Vasak-OS/tauri-plugin-i18n/pull/6) —una aplicación instalada deja de mirar el directorio actual—, y los dos arreglos son independientes: cada uno solo ya evita el problema, juntos lo cierran desde los dos lados.

## Test

`es_un_directorio_que_existe_y_no_el_del_escritorio`: comprueba que el directorio entregado sea absoluto, exista, y —cuando la prueba corre desde un directorio que tiene `locales/`, que es exactamente el caso que rompía— que no sea ése.

89 tests en verde, clippy limpio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop app launching by using a reliable, absolute startup directory.
  * Fixed settings launches that could fail or behave inconsistently depending on the current working directory.
  * Improved launch reliability by using the home directory as the startup location when opening apps and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->