### PR TITLE
fix(centro): las notificaciones se desplazan solas, y con la estética del sistema

### DIFF
--- a/src/components/areas/control-center/NotificationArea.vue
+++ b/src/components/areas/control-center/NotificationArea.vue
@@ -1,9 +1,10 @@
 <template>
-  <div
-		class="flex flex-col gap-2 w-full h-full overflow-y-auto p-4"
-  >
+  <!-- El encabezado queda fijo y la lista se desplaza sola: con el scroll en
+       todo el bloque, unas cuantas notificaciones empujaban los controles del
+       centro —música, brillo, volumen— fuera de la pantalla. -->
+  <div class="flex flex-col w-full min-h-0">
     <div
-      class="flex items-center justify-between mb-2"
+      class="flex shrink-0 items-center justify-between gap-2 px-1 pb-2"
       v-if="groupedNotifications.length > 0"
     >
       <span class="text-sm text-tx-main font-medium">
@@ -24,7 +25,7 @@
       </span>
       <button
         @click="clearAllNotifications"
-        class="text-xs px-4 py-2 bg-primary rounded-corner hover:bg-primary/80 transition-colors"
+        class="shrink-0 text-xs px-3 py-1 bg-primary text-tx-on-primary rounded-corner hover:bg-primary/80 transition-colors"
       >
         {{ t('components.NotificationArea.clearAll') }}
       </button>
@@ -32,13 +33,13 @@
 
     <div
       v-if="groupedNotifications.length === 0"
-      class="text-center transition-opacity duration-300 ease-in-out text-tx-muted py-8"
+      class="text-center transition-opacity duration-300 ease-in-out text-tx-muted py-6"
     >
-      <img :src="emptyIcon" alt="" class="w-8 h-8 opacity-60 mx-auto" />
-      <p class="mt-2">{{ t('components.NotificationArea.empty') }}</p>
+      <img :src="emptyIcon" alt="" class="w-6 h-6 opacity-60 mx-auto" />
+      <p class="mt-1 text-sm">{{ t('components.NotificationArea.empty') }}</p>
     </div>
 
-    <TransitionGroup move-class="transition-transform duration-300 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]" enter-active-class="transition-all duration-400 ease-[cubic-bezier(0.34,1.56,0.64,1)] [&>.notification-item]:animate-pulse-notification" leave-active-class="transition-all duration-300 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]" enter-from-class="opacity-0 translate-x-full scale-90" leave-to-class="opacity-0 translate-x-[-30%] scale-95" tag="div" class="flex flex-col gap-3">
+    <TransitionGroup move-class="transition-transform duration-300 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]" enter-active-class="transition-all duration-400 ease-[cubic-bezier(0.34,1.56,0.64,1)] [&>.notification-item]:animate-pulse-notification" leave-active-class="transition-all duration-300 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]" enter-from-class="opacity-0 translate-x-full scale-90" leave-to-class="opacity-0 translate-x-[-30%] scale-95" tag="div" class="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto overflow-x-hidden pr-1">
       <NotificationGroupCard
         v-for="group in groupedNotifications"
         :key="group.app_name"

--- a/src/components/cards/NotificationCard.vue
+++ b/src/components/cards/NotificationCard.vue
@@ -1,33 +1,37 @@
 <template>
+  <!-- Una notificación ocupa lo que dice y nada más: sin degradados propios,
+       sin sombra, sin levantarse al pasar el mouse y sin colores fuera de los
+       del sistema. Lo único que distingue a una sin leer es la barra al
+       costado, en el color de acento. El nombre de la aplicación no se repite
+       acá: ya está en el encabezado del grupo. -->
   <div
-    class="theme-transition border border-transparent bg-[linear-gradient(135deg,rgba(255,255,255,0.5),rgba(255,255,255,0.3))] dark:bg-[linear-gradient(135deg,rgba(0,0,0,0.5),rgba(0,0,0,0.3))] transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] hover:-translate-y-[2px] hover:border-blue-500/30 group/nc flex items-start gap-3 p-3 bg-ui-bg/80 rounded-corner shadow-sm transition-all duration-200 hover:shadow-lg"
+    class="theme-transition group/nc flex items-start gap-2 px-2 py-1.5 border-l-2 border-transparent transition-colors duration-200 hover:bg-ui-surface/60"
     :class="{
-      'opacity-75 scale-95': notification.seen,
-      'border-l-4 border-l-primary animate-notification-glow': !notification.seen,
+      'opacity-60': notification.seen,
+      'border-l-primary': !notification.seen,
       'cursor-pointer': hasDefaultAction,
     }" :data-urgency="notification.urgency?.toLowerCase()"
     :title="hasDefaultAction ? t('components.NotificationCard.openHint') : undefined"
     @click="handleDefaultAction">
-    <img :src="iconSrc" :alt="notification.app_name" class="w-10 h-10 object-contain transition-transform duration-200 ease-in-out group-hover/nc:scale-105" />
+    <img :src="iconSrc" :alt="notification.app_name" class="w-4 h-4 mt-0.5 shrink-0 object-contain" />
     <div class="flex-1 min-w-0">
-      <div class="flex items-center justify-between gap-2">
-        <h3 class="font-medium truncate">{{ notification.summary }}</h3>
-        <button @click="$emit('seen', notification.id)"
-          class="close-button group/close active:scale-95 flex items-center justify-center w-6 h-6 rounded-full text-gray-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 dark:text-gray-400 dark:hover:text-red-400 transition-all duration-200 transform hover:scale-110">
-          <img :src="closeIconSrc" :alt="t('common.close')" class="w-3 h-3 transition-transform duration-200" />
-        </button>
+      <div class="flex items-start justify-between gap-2">
+        <h3 class="text-sm font-medium text-tx-main truncate">{{ notification.summary }}</h3>
+        <div class="flex items-center gap-1 shrink-0">
+          <span class="text-[11px] text-tx-muted">{{ formatTime(notification.timestamp) }}</span>
+          <button @click.stop="$emit('seen', notification.id)"
+            :title="t('common.close')"
+            class="flex items-center justify-center w-4 h-4 rounded-full text-tx-muted opacity-0 transition-opacity duration-200 group-hover/nc:opacity-100 focus-visible:opacity-100 hover:text-status-error">
+            <img :src="closeIconSrc" :alt="t('common.close')" class="w-2.5 h-2.5" />
+          </button>
+        </div>
       </div>
-      <p class="text-sm text-tx-main line-clamp-2">
+      <p v-if="notification.body" class="text-xs text-tx-muted line-clamp-2">
         {{ notification.body }}
       </p>
-      <div class="flex items-center gap-2 mt-1 text-xs text-tx-muted">
-        <span>{{ notification.app_name }}</span>
-        <span>•</span>
-        <span>{{ formatTime(notification.timestamp) }}</span>
-      </div>
 
       <!-- Actions -->
-      <div v-if="parsedActions.length > 0" class="flex flex-wrap gap-2 mt-2" @click.stop>
+      <div v-if="parsedActions.length > 0" class="flex flex-wrap gap-1 mt-1" @click.stop>
         <ActionButton
           v-for="action in parsedActions"
           :key="action.key"

--- a/src/components/cards/NotificationGroupCard.vue
+++ b/src/components/cards/NotificationGroupCard.vue
@@ -6,7 +6,7 @@
          de juguete. Lo que indica que la fila responde al clic es el cursor y
          el giro de la flecha, que alcanza. -->
     <div
-      class="flex items-center gap-2 px-2 py-1.5 bg-ui-surface rounded-t-corner cursor-pointer"
+      class="group/grupo flex items-center gap-2 px-2 py-1.5 bg-ui-surface rounded-t-corner cursor-pointer"
       @click="toggleExpanded" :class="{ 'rounded-corner': !isExpanded }">
       <img :src="iconSrc" :alt="group.app_name" class="w-5 h-5 shrink-0 object-contain" />
 
@@ -30,16 +30,14 @@
         <span class="text-[11px] text-tx-muted">
           {{ formatTime(group.latest_timestamp) }}
         </span>
-        <ActionButton
-          label=""
-          :iconSrc="closeIconSrc"
-          :iconAlt="t('components.NotificationGroupCard.removeGroup')"
-          size="sm"
-          variant="secondary"
-          :stopPropagation="true"
-          customClass="bg-transparent border border-transparent text-tx-muted hover:text-status-error hover:bg-status-error/10"
-          @click="removeAllFromGroup"
-        />
+        <button
+          type="button"
+          :title="t('components.NotificationGroupCard.removeGroup')"
+          class="flex items-center justify-center w-4 h-4 rounded-full text-tx-muted opacity-0 transition-opacity duration-200 group-hover/grupo:opacity-100 focus-visible:opacity-100 hover:text-status-error"
+          @click.stop="removeAllFromGroup"
+        >
+          <img :src="closeIconSrc" :alt="t('components.NotificationGroupCard.removeGroup')" class="w-2.5 h-2.5" />
+        </button>
         <div class="w-4 h-4 flex items-center justify-center text-tx-muted transition-transform duration-200"
           :class="{ 'rotate-180': isExpanded }">
           <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -72,7 +70,6 @@ import { useI18n } from '@vasakgroup/tauri-plugin-i18n';
 import { computed, onMounted, ref } from 'vue';
 import NotificationCard from '@/components/cards/NotificationCard.vue';
 import { useIcons } from '@/tools/composables/useReactiveIcon';
-import ActionButton from '../buttons/ActionButton.vue';
 
 const { t } = useI18n();
 

--- a/src/components/cards/NotificationGroupCard.vue
+++ b/src/components/cards/NotificationGroupCard.vue
@@ -1,37 +1,33 @@
 <template>
   <div class="transition-all duration-200 ease-in-out">
-    <!-- Header del grupo -->
+    <!-- Encabezado del grupo.
+         Sin cambio de fondo al pasar el mouse: el barrido diagonal y el
+         degradado a azul y violeta que había acá no son del sistema y se veían
+         de juguete. Lo que indica que la fila responde al clic es el cursor y
+         el giro de la flecha, que alcanza. -->
     <div
-      class="group-header relative overflow-hidden before:content-[''] before:absolute before:inset-0 before:bg-[linear-gradient(45deg,transparent_49%,rgba(255,255,255,0.1)_50%,transparent_51%)] before:-translate-x-full before:transition-transform before:duration-600 before:ease-in-out hover:before:translate-x-full  flex items-center gap-3 p-3 bg-linear-to-r from-primary/50 to-secondary/50 rounded-t-corner border-l-4 border-primary cursor-pointer transition-all duration-200 hover:bg-linear-to-r hover:from-blue-100/50 hover:to-purple-100/50 dark:hover:from-blue-800/30 dark:hover:to-purple-800/30"
-      @click="toggleExpanded" :class="{
-        'rounded-corner': !isExpanded,
-        'shadow-sm': group.has_unread,
-      }">
-      <img :src="iconSrc" :alt="group.app_name" class="w-8 h-8 object-contain transition-transform duration-200"
-        :class="{ 'scale-110': group.has_unread }" />
+      class="flex items-center gap-2 px-2 py-1.5 bg-ui-surface rounded-t-corner cursor-pointer"
+      @click="toggleExpanded" :class="{ 'rounded-corner': !isExpanded }">
+      <img :src="iconSrc" :alt="group.app_name" class="w-5 h-5 shrink-0 object-contain" />
 
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
-          <h3 class="font-medium text-ui-main truncate">
+          <h3 class="text-sm font-medium text-tx-main truncate">
             {{ group.app_name }}
           </h3>
           <span
-            class="inline-flex items-center justify-center w-5 h-5 text-xs font-medium rounded-full transition-all duration-200"
-            :class="{
-              'bg-blue-500 text-white': group.has_unread,
-              'bg-ui-bg/80 text-ui-muted':
-                !group.has_unread,
-            }">
+            class="inline-flex items-center justify-center min-w-4 h-4 px-1 text-[11px] font-medium rounded-full"
+            :class="group.has_unread ? 'bg-primary text-tx-on-primary' : 'bg-ui-bg text-tx-muted'">
             {{ group.count }}
           </span>
         </div>
-        <p class="text-sm text-tx-muted truncate">
+        <p class="text-xs text-tx-muted truncate">
           {{ formatGroupSummary() }}
         </p>
       </div>
 
-      <div class="flex items-center gap-2">
-        <span class="text-xs text-tx-muted">
+      <div class="flex items-center gap-1 shrink-0">
+        <span class="text-[11px] text-tx-muted">
           {{ formatTime(group.latest_timestamp) }}
         </span>
         <ActionButton
@@ -41,12 +37,12 @@
           size="sm"
           variant="secondary"
           :stopPropagation="true"
-          customClass="bg-transparent text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 border border-transparent"
+          customClass="bg-transparent border border-transparent text-tx-muted hover:text-status-error hover:bg-status-error/10"
           @click="removeAllFromGroup"
         />
-        <div class="w-5 h-5 flex items-center justify-center transition-transform duration-200"
+        <div class="w-4 h-4 flex items-center justify-center text-tx-muted transition-transform duration-200"
           :class="{ 'rotate-180': isExpanded }">
-          <svg class="w-3 h-3 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
           </svg>
         </div>
@@ -57,7 +53,7 @@
       leave-active-class="transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] overflow-hidden"
       enter-from-class="h-0 opacity-0" leave-to-class="h-0 opacity-0" @enter="onEnter" @leave="onLeave">
       <div v-show="isExpanded"
-        class="notifications-list bg-ui-bg/80 rounded-b-vsk border-l-4 border-blue-500/30">
+        class="notifications-list bg-ui-bg/60 rounded-b-corner">
         <TransitionGroup move-class="transition-transform duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]"
           enter-active-class="transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]"
           leave-active-class="transition-all duration-200 ease-[cubic-bezier(0.4,0,0.2,1)]"

--- a/src/views/ControlCenterView.vue
+++ b/src/views/ControlCenterView.vue
@@ -88,14 +88,19 @@ onBeforeUnmount(() => {
 <template>
   <Transition appear enter-active-class="enter-active">
     <main
-      :class="['bg-ui-bg/80 h-screen w-screen rounded-corner flex flex-row flex-wrap justify-between p-1 border border-ui-border', { 'leave-active': leaving }]"
+      :class="['bg-ui-bg/80 h-screen w-screen rounded-corner flex flex-col justify-between p-1 border border-ui-border overflow-hidden', { 'leave-active': leaving }]"
     >
-      <div class="flex flex-col w-full gap-2 p-2">
+      <!-- `min-h-0` es lo que hace que el scroll sea de las notificaciones y no
+           del centro entero: sin él, un hijo flexible no se deja achicar por
+           debajo de su contenido, la lista empujaba y los controles de abajo
+           —música, brillo, volumen— se iban de la pantalla en cuanto había unas
+           cuantas notificaciones. -->
+      <div class="flex min-h-0 flex-1 flex-col w-full gap-2 p-2">
         <UserControlCenterCard />
         <PhoneControlCenterCard />
-        <NotificationArea />
+        <NotificationArea class="min-h-0 flex-1" />
       </div>
-      <div class="flex flex-wrap w-full justify-around items-end self-end p-2">
+      <div class="flex shrink-0 flex-wrap w-full justify-around items-end p-2">
         <MusicWidget class="w-full" />
         <div class="flex justify-between gap-2 w-full">
           <SearchButtonControl />

--- a/src/views/ControlCenterView.vue
+++ b/src/views/ControlCenterView.vue
@@ -101,7 +101,14 @@ onBeforeUnmount(() => {
         <NotificationArea class="min-h-0 flex-1" />
       </div>
       <div class="flex shrink-0 flex-wrap w-full justify-around items-end p-2">
-        <MusicWidget class="w-full" />
+        <!-- La caja va afuera y no como clase del widget: por dentro es
+             `h-full` —se adapta con consultas de contenedor— y una clase de
+             alto puesta desde acá compite con esa y pierde. Sin una altura
+             resuelta, la carátula se estira hasta tapar el brillo y el
+             volumen. -->
+        <div class="h-24 w-full">
+          <MusicWidget class="w-full" />
+        </div>
         <div class="flex justify-between gap-2 w-full">
           <SearchButtonControl />
           <NetworkControl />


### PR DESCRIPTION
Tres cosas del centro de notificaciones, verificadas con 200 notificaciones de cinco aplicaciones en pantalla.

## El scroll era del centro entero

Con unas cuantas notificaciones la lista empujaba, y los controles de abajo —música, brillo, volumen— se iban de la pantalla. Ahora el bloque de arriba es el que se achica y **la lista tiene su propio desplazamiento**, con el encabezado —cuántas hay, «limpiar todo»— fijo arriba.

La clave es el `min-h-0`: un hijo flexible no se deja achicar por debajo de su contenido, así que sin eso ningún `overflow` sirve.

## El encabezado de grupo cambiaba de fondo al pasar el mouse

Y no sólo: tenía un barrido diagonal blanco (`before:` con un `linear-gradient` a 45°) y un degradado a azul y violeta que no son colores del sistema. Se van los tres. Que la fila responde al clic lo dicen el cursor y el giro de la flecha.

## Las notificaciones ocupaban demasiado para lo que dicen

Cada una traía degradado propio, sombra, un salto al pasar el mouse, un brillo animado, el icono a 40 px y el nombre de la aplicación repetido debajo —cuando ya está en el encabezado del grupo—.

Queda el resumen, el cuerpo, la hora, y una barra al costado en el color de acento cuando está sin leer; la equis aparece al pasar por encima. Los colores sueltos —`blue-500`, `red-50`, `gray-400`, `purple-800`— pasan a ser los del tema: `primary`, `status-error`, `tx-muted`, `ui-surface`. El icono baja de 40 a 16 px y el del grupo de 32 a 20.

## Dos que aparecieron al verlo andando

- El botón de borrar un grupo salía como un **círculo de color en cada fila**. Era `ActionButton` con `variant="secondary"`: el `bg-transparent` del `customClass` compite con el `bg-secondary` de la variante, y en Tailwind gana el orden de la hoja, no el del atributo. Pasa a ser un botón propio que aparece al pasar el mouse, como el de cada notificación.
- El reproductor **se estiraba hasta tapar el brillo y el volumen**: por dentro es `h-full` y sin una altura resuelta arriba la carátula crecía con su tamaño natural. La caja va afuera, en un contenedor propio — una clase de alto sobre el componente compite con su `h-full` y pierde.

`vue-tsc` limpio y biome sin avisos. Verificado en la sesión: el binario compilado, el centro abierto con 200 notificaciones, y los controles de abajo completos.