### PR TITLE
Coherencia estética: las interfaces usan el sistema de diseño

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -25,10 +25,12 @@
   /* Colores de Texto */
   --text-main: #4c4f69;
   --text-muted: #6c6f85;
-  --text-on-primary: #5c5f77;
+  --text-on-primary: #1e1e2e;
+  --text-on-secondary: #eff1f5;
   --text-main-dark: #cdd6f4;
   --text-muted-dark: #a6adc8;
-  --text-on-primary-dark: #cdd6f4;
+  --text-on-primary-dark: #1e1e2e;
+  --text-on-secondary-dark: #1e1e2e;
 
   /* Status */
   --status-error: #d20f39;
@@ -91,6 +93,7 @@
   --use-text-main: var(--text-main);
   --use-text-muted: var(--text-muted);
   --use-text-on-primary: var(--text-on-primary);
+  --use-text-on-secondary: var(--text-on-secondary);
   --use-status-error: var(--status-error);
   --use-status-success: var(--status-success);
   --use-status-warning: var(--status-warning);
@@ -106,6 +109,7 @@
   --use-text-main: var(--text-main-dark);
   --use-text-muted: var(--text-muted-dark);
   --use-text-on-primary: var(--text-on-primary-dark);
+  --use-text-on-secondary: var(--text-on-secondary-dark);
   --use-status-error: var(--status-error-dark);
   --use-status-success: var(--status-success-dark);
   --use-status-warning: var(--status-warning-dark);
@@ -116,6 +120,12 @@
 @theme {
   /* radius */
   --radius-corner: var(--corner-radius);
+  /* El radio chico, para lo que no es una tarjeta: chips, insignias, el pulgar de
+     una barra. Derivado del que la persona configuró y no fijo, así que un
+     escritorio con esquinas rectas o muy redondeadas se ve coherente hasta en los
+     detalles — con `rounded-sm` a 2px, subir el radio general dejaba las tarjetas
+     redondas y los chips cuadrados. */
+  --radius-corner-sm: calc(var(--corner-radius) / 2.5);
   --radius-corner-window: calc(var(--corner-radius) + 2px);
 
   /* Colores de Marca - responsive a dark mode */
@@ -131,6 +141,7 @@
   --color-tx-main: var(--use-text-main);
   --color-tx-muted: var(--use-text-muted);
   --color-tx-on-primary: var(--use-text-on-primary);
+  --color-tx-on-secondary: var(--use-text-on-secondary);
 
   /* Status - responsive a dark mode */
   --color-status-error: var(--use-status-error);

--- a/src/components/areas/bluetooth/BluetoothControlArea.vue
+++ b/src/components/areas/bluetooth/BluetoothControlArea.vue
@@ -133,7 +133,7 @@ const disconnect = async (device: any) => {
         :disabled="isTogglingBluetooth"
         size="medium"
         active-class="bg-primary"
-        inactive-class="bg-gray-400"
+        inactive-class="bg-tx-muted"
         custom-class="mr-2 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
         @toggle="toggleBT"
       />

--- a/src/components/areas/panel/TrayBarArea.vue
+++ b/src/components/areas/panel/TrayBarArea.vue
@@ -177,7 +177,7 @@ useSharedEvent<{ has_battery?: boolean }>('battery-update', (payload) => {
         </div>
 
         <!-- Status indicator -->
-        <div v-if="item.status === 'NeedsAttention'" class="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full animate-pulse shadow-lg shadow-red-500/50" />
+        <div v-if="item.status === 'NeedsAttention'" class="absolute -top-1 -right-1 w-2 h-2 bg-status-error rounded-full animate-pulse shadow-lg shadow-red-500/50" />
       </div>
       <TrayIconSound key="icon-sound" />
       <TrayIconBattery v-if="existBattery" key="icon-battery" />

--- a/src/components/buttons/TrayIconBattery.vue
+++ b/src/components/buttons/TrayIconBattery.vue
@@ -28,9 +28,9 @@ const batteryAltText = computed(() => {
 });
 
 const tooltipClass = computed(() => ({
-	'text-green-400': batteryInfo.value.is_charging,
-	'text-red-400': batteryInfo.value.percentage < 20 && !batteryInfo.value.is_charging,
-	'text-yellow-400':
+	'text-status-success': batteryInfo.value.is_charging,
+	'text-status-error': batteryInfo.value.percentage < 20 && !batteryInfo.value.is_charging,
+	'text-status-warning':
 		batteryInfo.value.percentage < 50 &&
 		batteryInfo.value.percentage >= 20 &&
 		!batteryInfo.value.is_charging,

--- a/src/components/buttons/WindowPanelButton.vue
+++ b/src/components/buttons/WindowPanelButton.vue
@@ -33,7 +33,7 @@ const toggleWindow = async (): Promise<void> => {
       :title="title"
       class="w-6 h-6 transition-all duration-300 group-hover:rotate-3 group-hover:brightness-110"
     />
-    <div v-else class="w-6 h-6 bg-gray-500/50 rounded-corner animate-pulse" />
+    <div v-else class="w-6 h-6 bg-tx-muted/50 rounded-corner animate-pulse" />
   </div>
 </template>
 

--- a/src/components/cards/AppMenuCard.vue
+++ b/src/components/cards/AppMenuCard.vue
@@ -42,7 +42,7 @@ const openApp = async (path: string) => {
     />
     <div class="col-10 app-card-info ps-2 text-left">
       {{ app.name }}
-      <span class="text-muted" style="display: none">{{
+      <span class="text-ui-surface" style="display: none">{{
         app.description
       }}</span>
       <span style="display: none">{{ app.keywords }}</span>

--- a/src/components/cards/DeviceCard.vue
+++ b/src/components/cards/DeviceCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="flex items-center justify-between bg-ui-bg/80 rounded-corner border border-ui-border px-6 py-3 mb-4"
-    :class="[{ 'border-l-4 border-green-500': isConnected }, customClass]"
+    :class="[{ 'border-l-4 border-status-success': isConnected }, customClass]"
     @click="handleClick"
   >
     <div class="flex items-center gap-3 flex-1 min-w-0">

--- a/src/components/controls/AudioDeviceSelector.vue
+++ b/src/components/controls/AudioDeviceSelector.vue
@@ -76,7 +76,7 @@ function getDeviceName(device: AudioDevice): string {
 
 <template>
   <div class="space-y-2">
-    <div class="flex items-center gap-2 text-sm font-medium text-muted">
+    <div class="flex items-center gap-2 text-sm font-medium text-ui-surface">
       <img v-if="speakerIcon" :src="speakerIcon" :alt="t('components.AudioDeviceSelector.speakerAlt')" class="w-4 h-4" />
       <span>{{ t('components.AudioDeviceSelector.title') }}</span>
     </div>
@@ -104,7 +104,7 @@ function getDeviceName(device: AudioDevice): string {
           <div class="text-xs font-medium truncate">
             {{ getDeviceName(device) }}
           </div>
-          <div class="text-xs text-muted/70">
+          <div class="text-xs text-ui-surface/70">
             {{ t('components.AudioDeviceSelector.volume').replace('{0}', String(Math.round(device.volume * 100))) }}
           </div>
         </div>
@@ -116,7 +116,7 @@ function getDeviceName(device: AudioDevice): string {
       </div>
     </div>
 
-    <div v-else-if="isLoading" class="text-xs text-muted">
+    <div v-else-if="isLoading" class="text-xs text-ui-surface">
       {{ t('components.AudioDeviceSelector.loadingDevices') }}
     </div>
 

--- a/src/components/controls/BluetoothControl.vue
+++ b/src/components/controls/BluetoothControl.vue
@@ -42,9 +42,9 @@ const toggleBT = async (): Promise<void> => {
     <div
       class="absolute top-1 right-1 w-3 h-3 rounded-full transition-all duration-300"
       :class="{
-        'bg-blue-400 animate-pulse': isBluetoothOn && connectedDevicesCount > 0,
-        'bg-blue-400': isBluetoothOn && connectedDevicesCount === 0,
-        'bg-gray-400': !isBluetoothOn,
+        'bg-primary animate-pulse': isBluetoothOn && connectedDevicesCount > 0,
+        'bg-primary': isBluetoothOn && connectedDevicesCount === 0,
+        'bg-tx-muted': !isBluetoothOn,
       }"
     ></div>
 
@@ -63,7 +63,7 @@ const toggleBT = async (): Promise<void> => {
       :is-active="isBluetoothOn"
       :is-loading="isTogglingBluetooth"
       :custom-class="{
-        'ring-2 ring-blue-400/50': isBluetoothOn,
+        'ring-2 ring-primary/50': isBluetoothOn,
       }"
       @click="toggleBT"
     />

--- a/src/components/controls/BrightnessControl.vue
+++ b/src/components/controls/BrightnessControl.vue
@@ -75,6 +75,9 @@ async function updateBrightness() {
 }
 
 const getPercentageClass = (percentage: number) => {
+	// Amarillo y naranja como ilustración de la temperatura del brillo, no con
+	// los tokens de estado: un brillo alto **no es un estado del sistema**, y
+	// pintarlo de `status-warning` diría que algo anda mal.
 	if (percentage > 80) return 'text-yellow-500';
 	if (percentage < 20) return 'text-orange-500';
 	return '';

--- a/src/components/controls/SearchButtonControl.vue
+++ b/src/components/controls/SearchButtonControl.vue
@@ -27,7 +27,7 @@ const openSearch = async () => {
     <!-- Overlay decorativo como ThemeToggle -->
     <div
       class="absolute inset-0 rounded-corner transition-all duration-500"
-      :class="'bg-lineal-to-br from-primary to-primary-secondary'"
+      :class="'bg-linear-to-br from-primary to-secondary'"
       style="opacity: 0"
     ></div>
 

--- a/src/components/controls/ThemeToggle.vue
+++ b/src/components/controls/ThemeToggle.vue
@@ -10,9 +10,9 @@
     <div
       class="absolute inset-0 rounded-corner transition-all duration-500 pointer-events-none opacity-0 group-hover:opacity-100 group-hover:opacity-100 transition-opacity !opacity-100"
       :class="{
-        'bg-lineal-to-br from-orange-400/20 to-yellow-400/20':
+        'bg-linear-to-br from-orange-400/20 to-yellow-400/20':
           !(configStore?.config as any)?.style?.darkmode,
-        'bg-lineal-to-br from-purple-500/20 to-blue-600/20':
+        'bg-linear-to-br from-purple-500/20 to-blue-600/20':
           (configStore?.config as any)?.style?.darkmode,
       }"></div>
 
@@ -32,6 +32,10 @@
   </div>
 </template>
 
+<!-- Los amarillos, naranjas, azules y violetas de este control **no se
+     tokenizan**: son la ilustración del sol y de la luna, o sea el
+     significado del interruptor. Cambiarlos por los colores de marca haría
+     que los dos modos se vieran iguales y el control dejaría de decir nada. -->
 <script setup lang="ts">
 /** biome-ignore-all lint/correctness/noUnusedImports: <Use in template> */
 /** biome-ignore-all lint/correctness/noUnusedVariables: <Use in template> */

--- a/src/views/apps/SearchView.vue
+++ b/src/views/apps/SearchView.vue
@@ -224,8 +224,8 @@ function getCategoryLabel(category: string): string {
             class="search-result flex items-center gap-4 p-4 rounded-corner cursor-pointer transition-all duration-200 mb-2 ring-1 ring-primary/20"
             :class="
               index === selectedIndex
-                ? 'selected bg-gradient-to-r from-primary/20 to-primary/10 translate-x-2 shadow-md shadow-primary/15 ring-2 ring-primary/40 scale-[1.01]'
-                : 'hover:bg-gradient-to-r hover:from-primary/20 hover:to-primary/10 hover:translate-x-2 hover:shadow-md hover:shadow-primary/15 hover:ring-primary/30'
+                ? 'selected bg-linear-to-r from-primary/20 to-primary/10 translate-x-2 shadow-md shadow-primary/15 ring-2 ring-primary/40 scale-[1.01]'
+                : 'hover:bg-linear-to-r hover:from-primary/20 hover:to-primary/10 hover:translate-x-2 hover:shadow-md hover:shadow-primary/15 hover:ring-primary/30'
             "
             @click="executeResult(result)"
             @mouseenter="selectedIndex = index"


### PR DESCRIPTION
Barrido de coherencia estética sobre las nueve interfaces, midiendo en vez de opinar. El bloque de tokens (`@theme`) ya era **idéntico** en las nueve —ahí no había divergencia—, así que todo lo que sigue es código que no lo usaba.

## 🔴 207 clases apuntaban a colores que no existen

El hallazgo mayor. Nombres de shadcn/ui —`text-muted-foreground`, `bg-muted`, `border-destructive`, `bg-success`, `bg-warning`, `outline-ring`— que el tema de VasakOS **no define**. Tailwind no genera la utilidad, así que esos elementos se dibujaban **sin color**: el texto heredaba lo que hubiera y los fondos quedaban transparentes.

198 de las 207 estaban en el gestor de archivos. Mapeadas a los tokens reales: `foreground`→`tx-main`, `muted-foreground`→`tx-muted`, `muted`→`ui-surface`, `destructive`→`status-error`, `success`/`warning`→sus tokens, `ring`/`accent`→`primary`.

## 🔴 37 usos de una variable inexistente

`var(--primary-color, #0084ff)`. **`--primary-color` no está definida en ninguna parte** —el token es `--color-primary`— así que los 37 caían al respaldo hardcodeado. Y el respaldo es azul, cuando el primario de VasakOS es `#eba0ac` en oscuro y `#dd7878` en claro: los inputs de ajustes, las tarjetas de bluetooth y el lienzo de monitores se dibujaban con un color de marca ajeno **y no seguían el tema al cambiarlo**.

## 🔴 Tres clases que no existen y no se dibujaban

- `bg-lineal-to-br` (3 usos) — «lineal» quedó en español; en Tailwind 4 es `bg-linear-to-*`. Esos degradados nunca se vieron.
- `to-primary-secondary` — no es un token; los que hay son `primary` y `secondary`.
- `bg-destructive` en el centro de estado — el punto del estado «error» no tenía color.

## Coherencia de color

60 clases de la paleta de Tailwind mapeadas a los tokens semánticos: rojo→`status-error`, verde→`status-success`, amarillo/ámbar→`status-warning`, azul→`primary`, gris→`tx-muted`. De paso se sacan los duplicados `dark:` que los tokens vuelven innecesarios.

Casos que salieron de mirarlos y no de reemplazar en masa:

- **La cabecera de un grupo de notificaciones se contradecía**: degradado de marca `from-primary/50 to-secondary/50` que **al pasar el mouse cambiaba a azul/violeta hardcodeado**. Ahora intensifica el mismo degradado.
- **La barra de progreso cambiaba de color según el porcentaje** (azul→cian→verde), así que una operación al 85 % se veía del verde de «listo» sin haber terminado, y el mismo verde significaba dos cosas en la misma ventana. El color codifica **estado**: acento mientras avanza, éxito al terminar. Para el progreso ya está el largo de la barra.
- **El azul de «bluetooth encendido» chocaba con el azul de «modo oscuro»** en el mismo panel: dos significados para el mismo color. El estado activo va en el acento.

Y lo que **no** se tokenizó, documentado en el código para que un barrido futuro no lo «arregle»: los amarillos y azules del interruptor de tema son la ilustración del sol y la luna —el significado del control—, y los del brillo son temperatura, no un estado del sistema.

## Radios

32 lugares con radios fijos (`rounded-sm/md/lg/xl/2xl`) ignoraban el radio que la persona configura. Se agrega `--radius-corner-sm`, **derivado** del suyo (`/2.5`) y no fijo: con `rounded-sm` a 2px, subir el radio general dejaba las tarjetas redondas y los chips cuadrados. Los de tarjeta van a `rounded-corner`, los chicos al nuevo. `rounded-full` se queda: es un círculo, no un radio de caja.

## Verificación

- Los nueve `@theme` siguen byte a byte idénticos entre sí.
- `vue-tsc` sin errores en las nueve apps.
- CSS compilado: las utilidades nuevas se generan (`.text-tx-muted`, `.bg-status-error`, `.rounded-corner-sm`, `.focus-visible\:outline-primary`) y **cero** nombres de shadcn quedan en la salida.
- Requiere `vasak-desktop-settings` al día, donde el esquema corrige `on-primary` y agrega `on-secondary`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated interface colors and spacing to use consistent theme tokens across controls, cards, status indicators, and battery information.
  * Improved light and dark mode text contrast.
  * Refined gradients in search, theme, and selection interfaces.
  * Added consistent small-corner radius styling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->