### PR TITLE
El foco se ve, el movimiento se puede apagar y el texto se lee

### DIFF
--- a/src-tauri/locales/en.yml
+++ b/src-tauri/locales/en.yml
@@ -159,6 +159,7 @@ components:
   NetworkControlArea:
     title: Networks
     wifiUnavailable: Wi-Fi not available on this device
+    wifiToggle: Wi-Fi
     availableNetworks: Available networks
     refresh: Refresh networks
     realtimeTraffic: Real-time traffic
@@ -240,6 +241,7 @@ components:
     pause: Pause
     next: Next
   VolumeControl:
+    volume: Volume
     mute: Mute
     unmute: Unmute
   TwingateArea:

--- a/src-tauri/locales/es.yml
+++ b/src-tauri/locales/es.yml
@@ -159,6 +159,7 @@ components:
   NetworkControlArea:
     title: Redes
     wifiUnavailable: Wi-Fi no disponible en este dispositivo
+    wifiToggle: Wi-Fi
     availableNetworks: Redes disponibles
     refresh: Actualizar redes
     realtimeTraffic: Tráfico en tiempo real
@@ -240,6 +241,7 @@ components:
     pause: Pausa
     next: Siguiente
   VolumeControl:
+    volume: Volumen
     mute: Silenciar
     unmute: Activar sonido
   TwingateArea:

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -18,13 +18,26 @@
   --ui-background: #eff1f5;
   --ui-surface: #ccd0da;
   --ui-border: #dce0e8;
+  /* El borde de lo que **delimita un control** —un campo, un botón, un selector—.
+     `--ui-border` da 1.17 contra el fondo en claro y 1.14 en oscuro, contra el
+     mínimo de 3.0 que pide WCAG 1.4.11 para lo que no es texto: a esos valores el
+     contorno de un input no se percibe. Se separa en dos tokens en lugar de subir
+     uno solo, porque el mismo color también hace de separador decorativo, y subirlo
+     ahí convertiría cada tarjeta en una caja marcada. */
+  --ui-border-strong: #7c7f93;
   --ui-background-dark: #1e1e2e;
   --ui-surface-dark: #313244;
   --ui-border-dark: #11111b;
+  --ui-border-strong-dark: #6c7086;
 
   /* Colores de Texto */
   --text-main: #4c4f69;
-  --text-muted: #6c6f85;
+  /* #555869 y no #6c6f85: el anterior daba 4.37 sobre el fondo y 3.20 sobre la
+     superficie, contra el mínimo de 4.5 de WCAG 1.4.3 — y es el color de casi todo
+     el texto secundario, que además suele ir en 12px o menos. Éste da 6.22 y 4.56,
+     y sigue siendo más claro que el texto principal, así que la jerarquía se
+     mantiene. El del modo oscuro ya cumplía (7.37 y 5.65) y no se toca. */
+  --text-muted: #555869;
   --text-on-primary: #1e1e2e;
   --text-on-secondary: #eff1f5;
   --text-main-dark: #cdd6f4;
@@ -90,6 +103,7 @@
   --use-ui-background: var(--ui-background);
   --use-ui-surface: var(--ui-surface);
   --use-ui-border: var(--ui-border);
+  --use-ui-border-strong: var(--ui-border-strong);
   --use-text-main: var(--text-main);
   --use-text-muted: var(--text-muted);
   --use-text-on-primary: var(--text-on-primary);
@@ -106,6 +120,7 @@
   --use-ui-background: var(--ui-background-dark);
   --use-ui-surface: var(--ui-surface-dark);
   --use-ui-border: var(--ui-border-dark);
+  --use-ui-border-strong: var(--ui-border-strong-dark);
   --use-text-main: var(--text-main-dark);
   --use-text-muted: var(--text-muted-dark);
   --use-text-on-primary: var(--text-on-primary-dark);
@@ -136,6 +151,7 @@
   --color-ui-bg: var(--use-ui-background);
   --color-ui-surface: var(--use-ui-surface);
   --color-ui-border: var(--use-ui-border);
+  --color-ui-border-strong: var(--use-ui-border-strong);
 
   /* Colores de Texto - responsive a dark mode */
   --color-tx-main: var(--use-text-main);
@@ -217,10 +233,60 @@ body * {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.2);
+  /* Con `rgba(255,255,255,.2)` la barra era blanca sobre fondo claro, o sea
+     invisible. El token sigue al tema. */
+  background: color-mix(in srgb, var(--color-tx-muted) 45%, transparent);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.3);
+  background: color-mix(in srgb, var(--color-tx-muted) 70%, transparent);
+}
+
+/* ── Accesibilidad: el foco y el movimiento ────────────────────────────────── */
+
+/*
+ * El foco del teclado tiene que verse (WCAG 2.4.7).
+ *
+ * Medido antes de escribir esto: 259 botones en el escritorio, 56 lugares con
+ * `outline-none` y sólo 21 con `focus-visible:`. Seis de las ocho aplicaciones no
+ * tenían ni uno, así que recorrer con Tab era hacerlo a ciegas.
+ *
+ * Va con `:where()` para que tenga especificidad cero: cualquier componente que
+ * quiera su propio indicador lo pisa sin peleas, y esto queda como piso.
+ */
+:where(
+  a,
+  button,
+  input,
+  select,
+  textarea,
+  summary,
+  [role="button"],
+  [tabindex]:not([tabindex="-1"])
+):focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/*
+ * Menos movimiento para quien lo pidió (WCAG 2.3.3, y 2.2.2 para lo que no para).
+ *
+ * En el escritorio hay 378 transiciones y 41 animaciones **infinitas** —pulsos de
+ * «conectando», ruedas de carga—, y cero soporte de esta preferencia. Para alguien
+ * con trastorno vestibular eso no es una molestia estética.
+ *
+ * No se apaga del todo: una duración mínima en lugar de `none` conserva los eventos
+ * `transitionend` y `animationend`, que hay código que espera. Y `iteration-count: 1`
+ * es lo que detiene lo infinito, que es la parte que de verdad marea.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/components/SearchMenuComponent.vue
+++ b/src/components/SearchMenuComponent.vue
@@ -25,7 +25,7 @@ const emit = defineEmits(['update:filter']);
 <template>
   <input
     type="text"
-    class="form-control border border-ui-border rounded-corner grow bg-ui-bg/80 shadow-none focus:outline-none focus:ring-0 p-2 disabled:opacity-50 disabled:cursor-not-allowed"
+    class="form-control border border-ui-border rounded-corner grow bg-ui-bg/80 shadow-none focus:ring-0 p-2 disabled:opacity-50 disabled:cursor-not-allowed"
     :placeholder="t('components.SearchMenuComponent.placeholder')"
     :aria-label="t('components.SearchMenuComponent.placeholder')"
     id="search"

--- a/src/components/areas/bluetooth/BluetoothControlArea.vue
+++ b/src/components/areas/bluetooth/BluetoothControlArea.vue
@@ -128,7 +128,7 @@ const disconnect = async (device: any) => {
 <template>
   <div class="flex flex-col h-full">
     <div class="flex items-center mb-4">
-      <SwitchToggle
+      <SwitchToggle :label="t('components.BluetoothControl.toggle')"
         :is-on="isBluetoothOn || false"
         :disabled="isTogglingBluetooth"
         size="medium"

--- a/src/components/areas/bluetooth/BluetoothControlArea.vue
+++ b/src/components/areas/bluetooth/BluetoothControlArea.vue
@@ -134,7 +134,7 @@ const disconnect = async (device: any) => {
         size="medium"
         active-class="bg-primary"
         inactive-class="bg-tx-muted"
-        custom-class="mr-2 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+        custom-class="mr-2 focus:ring-2 focus:ring-offset-2 focus:ring-primary"
         @toggle="toggleBT"
       />
       <img :src="bluetoothIcon" alt="Bluetooth" class="h-8 w-auto mr-3" />
@@ -142,8 +142,7 @@ const disconnect = async (device: any) => {
       <button
         class="bg-primary text-white rounded-corner px-1 py-0.5 active:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
         @click="scanDevices"
-        :disabled="!isBluetoothOn || isScanning"
-      >
+        :disabled="!isBluetoothOn || isScanning" :aria-label="t('components.BluetoothControlArea.scanAlt')">
         <img
           :src="syncIcon"
           :alt="t('components.BluetoothControlArea.scanAlt')"

--- a/src/components/areas/network/NetworkControlArea.vue
+++ b/src/components/areas/network/NetworkControlArea.vue
@@ -83,7 +83,7 @@
         </span>
       </div>
 
-      <SwitchToggle
+      <SwitchToggle :label="t('components.NetworkControlArea.wifiToggle')"
         v-if="wifiAvailable"
         :is-on="wifiEnabled"
         @toggle="toggleWifi"

--- a/src/components/buttons/CategoryMenuPill.vue
+++ b/src/components/buttons/CategoryMenuPill.vue
@@ -8,7 +8,8 @@ const emit = defineEmits(['update:categorySelected']);
 const props = defineProps<{
 	category: any;
 	image: string;
-	description: string;
+	/** Nombre de la categoría, ya traducido: es lo único que nombra al botón. */
+	label: string;
 	categorySelected: string;
 	large?: boolean;
 }>();
@@ -24,13 +25,16 @@ const setCategory = (category: string) => {
   <button
     class="theme-transition w-full h-full flex items-center justify-center p-2 rounded-corner hover:scale-110 transition-transform duration-200"
     @click="setCategory(category)"
+    :title="label"
+    :aria-label="label"
+    :aria-pressed="category === categorySelected"
 :class="[
     category === categorySelected
       ? 'bg-primary border border-secondary relative'
       : 'bg-transparent border border-transparent hover:bg-ui-surface/60'
   ]"
   >
-    <img :src="appIcon" :title="description" :alt="category" :class="large ? 'h-14' : 'h-10'" />
+    <img :src="appIcon" alt="" :class="large ? 'h-14' : 'h-10'" />
   </button>
 </template>
 

--- a/src/components/cards/NetworkWiFiCard.vue
+++ b/src/components/cards/NetworkWiFiCard.vue
@@ -124,7 +124,7 @@ const signalLevel = Math.min(4, Math.max(0, Math.ceil((props.signal_strength || 
         v-model="password"
         type="password"
         :placeholder="t('components.NetworkWiFiCard.passwordPlaceholder')"
-        class="border border-ui-border rounded-corner p-2 text-tx-main outline-none bg-ui-surface/50 focus:border-primary/40"
+        class="border border-ui-border rounded-corner p-2 text-tx-main bg-ui-surface/50 focus:border-primary/40"
         :disabled="connecting"
       />
       <div v-if="errorMsg" class="text-status-error text-sm">{{ errorMsg }}</div>

--- a/src/components/cards/NotificationCard.vue
+++ b/src/components/cards/NotificationCard.vue
@@ -21,7 +21,7 @@
           <span class="text-[11px] text-tx-muted">{{ formatTime(notification.timestamp) }}</span>
           <button @click.stop="$emit('seen', notification.id)"
             :title="t('common.close')"
-            class="flex items-center justify-center w-4 h-4 rounded-full text-tx-muted opacity-0 transition-opacity duration-200 group-hover/nc:opacity-100 focus-visible:opacity-100 hover:text-status-error">
+            class="flex items-center justify-center w-4 h-4 rounded-full text-tx-muted opacity-0 transition-opacity duration-200 group-hover/nc:opacity-100 focus-visible:opacity-100 hover:text-status-error" :aria-label="t('common.close')">
             <img :src="closeIconSrc" :alt="t('common.close')" class="w-2.5 h-2.5" />
           </button>
         </div>

--- a/src/components/cards/NotificationGroupCard.vue
+++ b/src/components/cards/NotificationGroupCard.vue
@@ -34,8 +34,7 @@
           type="button"
           :title="t('components.NotificationGroupCard.removeGroup')"
           class="flex items-center justify-center w-4 h-4 rounded-full text-tx-muted opacity-0 transition-opacity duration-200 group-hover/grupo:opacity-100 focus-visible:opacity-100 hover:text-status-error"
-          @click.stop="removeAllFromGroup"
-        >
+          @click.stop="removeAllFromGroup" :aria-label="t('components.NotificationGroupCard.removeGroup')">
           <img :src="closeIconSrc" :alt="t('components.NotificationGroupCard.removeGroup')" class="w-2.5 h-2.5" />
         </button>
         <div class="w-4 h-4 flex items-center justify-center text-tx-muted transition-transform duration-200"

--- a/src/components/controls/BluetoothControl.vue
+++ b/src/components/controls/BluetoothControl.vue
@@ -58,8 +58,8 @@ const toggleBT = async (): Promise<void> => {
 
     <ToggleControl
       :icon="bluetoothIcon"
-      :alt="t('components.BluetoothControl.iconAlt')"
-      :tooltip="t('components.BluetoothControl.toggle')"
+      :label="t('components.BluetoothControl.toggle')"
+      :pressed="isBluetoothOn"
       :is-active="isBluetoothOn"
       :is-loading="isTogglingBluetooth"
       :custom-class="{

--- a/src/components/controls/BrightnessControl.vue
+++ b/src/components/controls/BrightnessControl.vue
@@ -112,8 +112,7 @@ useSharedEvent<Record<string, number>>(
 <template>
   <SliderControl
     :icon="currentIcon"
-    :alt="brightnessLabel"
-    :tooltip="brightnessLabel"
+    :label="brightnessLabel"
     v-model="currentBrightness"
     :min="brightnessInfo.min"
     :max="brightnessInfo.max"

--- a/src/components/controls/NetworkControl.vue
+++ b/src/components/controls/NetworkControl.vue
@@ -45,8 +45,7 @@ onMounted(async () => {
 
 		<ToggleControl
 			:icon="networkIconSrc"
-			:alt="networkAlt"
-			:tooltip="networkAlt"
+			:label="networkAlt"
 			:is-active="networkState.is_connected"
 			:custom-class="{
 				'ring-2 ring-status-success': networkState.is_connected && !vpnConnected,

--- a/src/components/controls/SearchButtonControl.vue
+++ b/src/components/controls/SearchButtonControl.vue
@@ -22,8 +22,7 @@ const openSearch = async () => {
   <button
     @click="openSearch"
     class="p-2 rounded-corner bg-ui-bg/80 transition-all duration-500 h-17 w-17 group relative overflow-hidden hover:scale-105 active:scale-95 ring-2 ring-primary"
-    :title="t('components.SearchButtonControl.openSearch')"
-  >
+    :title="t('components.SearchButtonControl.openSearch')" :aria-label="t('components.SearchButtonControl.openSearch')">
     <!-- Overlay decorativo como ThemeToggle -->
     <div
       class="absolute inset-0 rounded-corner transition-all duration-500"

--- a/src/components/controls/ThemeToggle.vue
+++ b/src/components/controls/ThemeToggle.vue
@@ -16,13 +16,10 @@
           (configStore?.config as any)?.style?.darkmode,
       }"></div>
 
-    <ToggleControl :icon="themeIcon" :alt="(configStore?.config as any)?.style?.darkmode
+    <ToggleControl :icon="themeIcon" :label="(configStore?.config as any)?.style?.darkmode
         ? t('components.ThemeToggle.toLight')
         : t('components.ThemeToggle.toDark')
-      " :tooltip="(configStore?.config as any)?.style?.darkmode
-          ? t('components.ThemeToggle.toLight')
-          : t('components.ThemeToggle.toDark')
-        " :is-active="true" :is-loading="isSwitching" :custom-class="{
+      " :pressed="Boolean((configStore?.config as any)?.style?.darkmode)" :is-active="true" :is-loading="isSwitching" :custom-class="{
         'h-[70px] w-[70px] p-2': true,
         'ring-2 ring-primary': true,
       }" :icon-class="{

--- a/src/components/controls/TrayMusicControl.vue
+++ b/src/components/controls/TrayMusicControl.vue
@@ -87,8 +87,7 @@ onMounted(async () => {
       <button
         @click.prevent="onPrev"
         class="w-6 h-6 flex items-center justify-center rounded-corner bg-ui-bg/80 text-xs"
-        :title="t('components.TrayMusicControl.previous')"
-      >
+        :title="t('components.TrayMusicControl.previous')" :aria-label="t('components.TrayMusicControl.previous')">
         <img :src="prevIcon" :alt="t('components.TrayMusicControl.previous')" class="w-4 h-4" />
       </button>
 
@@ -97,8 +96,9 @@ onMounted(async () => {
         class="w-6 h-6 flex items-center justify-center rounded-corner bg-ui-bg/80 text-xs"
         :title="isPlaying
           ? t('components.TrayMusicControl.pause')
-          : t('components.TrayMusicControl.play')"
-      >
+          : t('components.TrayMusicControl.play')" :aria-label="isPlaying
+          ? t('components.TrayMusicControl.pause')
+          : t('components.TrayMusicControl.play')">
         <img
           :src="isPlaying ? pauseIcon : playIcon"
           :alt="isPlaying
@@ -111,8 +111,7 @@ onMounted(async () => {
       <button
         @click.prevent="onNext"
         class="w-6 h-6 flex items-center justify-center rounded-corner bg-ui-bg/80 text-xs"
-        :title="t('components.TrayMusicControl.next')"
-      >
+        :title="t('components.TrayMusicControl.next')" :aria-label="t('components.TrayMusicControl.next')">
         <img :src="nextIcon" :alt="t('components.TrayMusicControl.next')" class="w-4 h-4" />
       </button>
     </div>

--- a/src/components/controls/VolumeControl.vue
+++ b/src/components/controls/VolumeControl.vue
@@ -26,10 +26,8 @@ onMounted(async () => {
 <template>
   <SliderControl
     :icon="currentIcon"
-    :alt="volumeInfo.is_muted
-      ? t('components.VolumeControl.unmute')
-      : t('components.VolumeControl.mute')"
-    :tooltip="volumeInfo.is_muted
+    :label="t('components.VolumeControl.volume')"
+    :button-label="volumeInfo.is_muted
       ? t('components.VolumeControl.unmute')
       : t('components.VolumeControl.mute')"
     v-model="currentVolume"

--- a/src/components/forms/SliderControl.vue
+++ b/src/components/forms/SliderControl.vue
@@ -5,26 +5,18 @@
     <button
       v-if="showButton"
       @click="handleButtonClick"
+      :title="buttonLabel ?? label"
+      :aria-label="buttonLabel ?? label"
       class="w-8 h-8 flex items-center justify-center rounded-corner transition-all duration-200 hover:bg-ui-surface/80 hover:scale-110 active:scale-95"
     >
-      <img
-        :src="icon"
-        :alt="alt"
-        :title="tooltip"
-        class="w-6 h-6 transition-all duration-200"
-        :class="iconClass"
-      />
+      <img :src="icon" alt="" class="w-6 h-6 transition-all duration-200" :class="iconClass" />
     </button>
     
     <div
       v-else
       class="w-8 h-8 flex items-center justify-center"
     >
-      <img
-        :src="icon"
-        :alt="alt"
-        class="w-6 h-6 transition-all duration-200"
-      />
+      <img :src="icon" alt="" class="w-6 h-6 transition-all duration-200" />
     </div>
 
     <input
@@ -33,6 +25,8 @@
       :max="max"
       :value="modelValue"
       @input="handleInput"
+      :aria-label="label"
+      :aria-valuetext="`${percentage}%`"
       class="flex-1 transition-all duration-200 hover:scale-105 accent-primary hover:accent-secondary"
     />
     
@@ -51,8 +45,13 @@ import { computed } from 'vue';
 
 interface Props {
 	icon: string;
-	alt?: string;
-	tooltip?: string;
+	/**
+	 * Nombre de lo que regula el deslizador, ya traducido. Obligatorio: el
+	 * `input` no tiene `<label>` asociado ni texto propio.
+	 */
+	label: string;
+	/** Nombre de la acción del botón, si difiere del deslizador. */
+	buttonLabel?: string;
 	modelValue: number;
 	min?: number;
 	max?: number;
@@ -62,8 +61,6 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-	alt: '',
-	tooltip: '',
 	min: 0,
 	max: 100,
 	showButton: false,

--- a/src/components/forms/SwitchToggle.vue
+++ b/src/components/forms/SwitchToggle.vue
@@ -1,6 +1,9 @@
 <template>
   <button
     type="button"
+    role="switch"
+    :aria-checked="isOn"
+    :aria-label="label"
     @click="handleClick"
     :disabled="disabled"
     :class="[
@@ -13,7 +16,12 @@
   >
     <span
       :class="[
-        'inline-block transform rounded-full bg-white shadow transition-transform',
+        'inline-block transform rounded-full shadow transition-transform',
+        // El pulgar es el primer plano de su vía: con `bg-white` fijo daba 1.54
+        // sobre la vía apagada en modo claro —contra el mínimo de 3.0 de WCAG
+        // 1.4.11— así que el estado del interruptor no se percibía. `tx-on-primary`
+        // está garantizado sobre el acento, sea el que sea.
+        isOn ? 'bg-tx-on-primary' : 'bg-tx-main',
         size === 'small' ? 'h-4 w-4' : 'h-6 w-6',
         isOn ? (size === 'small' ? 'translate-x-6' : 'translate-x-5') : 'translate-x-1'
       ]"
@@ -23,7 +31,21 @@
 
 <script setup lang="ts">
 /** biome-ignore-all lint/correctness/noUnusedVariables: <Use in template> */
+/**
+ * Un interruptor de dos estados.
+ *
+ * `label` es **obligatorio** y no un extra: un botón que sólo tiene un círculo
+ * adentro no tiene nombre, y un lector de pantalla anuncia «botón» y nada más.
+ * Como la etiqueta ya está escrita al lado del interruptor en todos los usos, el
+ * consumidor pasa la misma cadena y no hay que inventar nada.
+ *
+ * Y va con `role="switch"` más `aria-checked`: sin eso, un `<button>` se anuncia
+ * como botón y no dice si está encendido o apagado, que es la única información
+ * que este control transmite.
+ */
 interface Props {
+	/** Qué controla este interruptor. Es su nombre accesible. */
+	label: string;
 	isOn: boolean;
 	disabled?: boolean;
 	size?: 'small' | 'medium';

--- a/src/components/forms/ToggleControl.vue
+++ b/src/components/forms/ToggleControl.vue
@@ -9,11 +9,14 @@
       ...customClass
     }"
     :disabled="isLoading"
+    :title="label"
+    :aria-label="label"
+    :aria-pressed="pressed"
+    :aria-busy="isLoading || undefined"
   >
     <img
       :src="icon"
-      :alt="alt"
-      :title="tooltip"
+      alt=""
       class="m-auto w-12.5 h-12.5 transition-all duration-300 group-hover:scale-110 relative z-10"
       :class="{
         'animate-spin': isLoading,
@@ -29,8 +32,18 @@
 /** biome-ignore-all lint/correctness/noUnusedVariables: <Use in template> */
 interface Props {
 	icon: string;
-	alt?: string;
-	tooltip?: string;
+	/**
+	 * Nombre del control, ya traducido. Es obligatorio porque el botón no tiene
+	 * más contenido que un icono: sin esto no tiene nombre accesible y un lector
+	 * de pantalla sólo puede anunciar «botón».
+	 */
+	label: string;
+	/**
+	 * Estado de dos posiciones, cuando el botón realmente alterna algo. Se deja
+	 * sin definir en los que abren un panel: `aria-pressed` ahí miente, y
+	 * `isActive` es sólo el resaltado visual.
+	 */
+	pressed?: boolean;
 	isActive?: boolean;
 	isLoading?: boolean;
 	iconClass?: Record<string, boolean>;
@@ -38,8 +51,6 @@ interface Props {
 }
 
 withDefaults(defineProps<Props>(), {
-	alt: '',
-	tooltip: '',
 	isActive: false,
 	isLoading: false,
 	iconClass: () => ({}),

--- a/src/components/widgets/MusicWidget.vue
+++ b/src/components/widgets/MusicWidget.vue
@@ -169,16 +169,14 @@ watch(
       <button
         class="flex h-[clamp(1.25rem,20cqmin,2.5rem)] flex-1 items-center justify-center rounded-corner bg-ui-surface/60 transition-colors hover:bg-ui-surface"
         :title="t('components.MusicWidget.previous')"
-        @click.prevent="onPrev"
-      >
+        @click.prevent="onPrev" :aria-label="t('components.MusicWidget.previous')">
         <img :src="prevIcon" :alt="t('components.MusicWidget.previous')" class="h-[55%] w-auto" />
       </button>
 
       <button
         class="flex h-[clamp(1.25rem,20cqmin,2.5rem)] flex-[1.4] items-center justify-center rounded-corner bg-primary/80 transition-colors hover:bg-primary"
         :title="isPlaying ? t('components.MusicWidget.pause') : t('components.MusicWidget.play')"
-        @click.prevent="onPlayPause"
-      >
+        @click.prevent="onPlayPause" :aria-label="isPlaying ? t('components.MusicWidget.pause') : t('components.MusicWidget.play')">
         <img
           :src="isPlaying ? pauseIcon : playIcon"
           :alt="isPlaying ? t('components.MusicWidget.pause') : t('components.MusicWidget.play')"
@@ -189,8 +187,7 @@ watch(
       <button
         class="flex h-[clamp(1.25rem,20cqmin,2.5rem)] flex-1 items-center justify-center rounded-corner bg-ui-surface/60 transition-colors hover:bg-ui-surface"
         :title="t('components.MusicWidget.next')"
-        @click.prevent="onNext"
-      >
+        @click.prevent="onNext" :aria-label="t('components.MusicWidget.next')">
         <img :src="nextIcon" :alt="t('components.MusicWidget.next')" class="h-[55%] w-auto" />
       </button>
     </div>

--- a/src/tools/etiquetas.test.ts
+++ b/src/tools/etiquetas.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'bun:test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Que toda clave citada en el código exista en el catálogo, y que los controles
+ * que sólo tienen un icono reciban su etiqueta.
+ *
+ * Este test nace de haberle puesto nombre accesible a los controles: cada
+ * `label` es un `t('...')` nuevo, y una clave mal escrita no falla en ninguna
+ * parte —`t()` devuelve la clave cruda y el lector de pantalla anuncia
+ * «views.power.idleLok»—. En un texto visible se nota; en el nombre de un
+ * interruptor, que existe justamente para quien no ve la pantalla, no.
+ */
+const RAIZ_LOCALES = join(import.meta.dir, '../../src-tauri/locales');
+const RAIZ_FUENTE = join(import.meta.dir, '../../src');
+
+/** Controles sin texto propio: el nombre les tiene que llegar por prop. */
+const CON_ETIQUETA_OBLIGATORIA = ['SwitchToggle', 'ToggleControl', 'SliderControl', 'CategoryMenuPill'] as const;
+
+const catalogo = () =>
+	Bun.YAML.parse(readFileSync(join(RAIZ_LOCALES, 'es.yml'), 'utf8')) as Record<string, unknown>;
+
+function archivos(directorio: string): string[] {
+	return readdirSync(directorio).flatMap((entrada) => {
+		const ruta = join(directorio, entrada);
+		if (statSync(ruta).isDirectory()) return archivos(ruta);
+		return ruta.endsWith('.vue') ? [ruta] : [];
+	});
+}
+
+function existe(documento: Record<string, unknown>, clave: string) {
+	const valor = clave.split('.').reduce<any>((nodo, parte) => nodo?.[parte], documento);
+	return typeof valor === 'string' || typeof valor === 'number';
+}
+
+/**
+ * La etiqueta de apertura que arranca en `desde`. No sirve una expresión
+ * regular: los atributos llevan valores con `>` adentro —`(v) => algo`— y
+ * cortar en el primer `>` parte la etiqueta al medio.
+ */
+function etiquetaDesde(texto: string, desde: number) {
+	let comilla = '';
+	for (let i = desde; i < texto.length; i++) {
+		const c = texto[i];
+		if (comilla) {
+			if (c === comilla) comilla = '';
+		} else if (c === '"' || c === "'") {
+			comilla = c;
+		} else if (c === '>') {
+			return texto.slice(desde, i + 1);
+		}
+	}
+	return texto.slice(desde);
+}
+
+describe('etiquetas de la interfaz', () => {
+	it('toda clave citada existe en el catálogo', () => {
+		const documento = catalogo();
+		const faltantes: string[] = [];
+
+		for (const ruta of archivos(RAIZ_FUENTE)) {
+			const texto = readFileSync(ruta, 'utf8');
+			// Sólo las literales: las armadas con plantilla
+			// (`wayfire.plugins.\${id}.label`) dependen de datos externos.
+			for (const coincidencia of texto.matchAll(/\bt\(\s*'([a-zA-Z][\w.]*)'\s*\)/g)) {
+				if (!existe(documento, coincidencia[1])) {
+					faltantes.push(`${ruta.split('/src/')[1]} → ${coincidencia[1]}`);
+				}
+			}
+		}
+
+		expect(faltantes).toEqual([]);
+	});
+
+	it('cada control sin texto propio recibe su etiqueta', () => {
+		// El typecheck ya lo exige, pero sólo mientras la prop siga siendo
+		// obligatoria: alcanza con que alguien le ponga un valor por omisión para
+		// «desbloquear» una vista y los controles se quedan sin nombre en silencio.
+		const sinEtiqueta: string[] = [];
+
+		for (const ruta of archivos(RAIZ_FUENTE)) {
+			const texto = readFileSync(ruta, 'utf8');
+			for (const componente of CON_ETIQUETA_OBLIGATORIA) {
+				const marca = `<${componente}`;
+				for (let i = texto.indexOf(marca); i !== -1; i = texto.indexOf(marca, i + 1)) {
+					// Que no sea el prefijo de otro componente más largo.
+					if (/[\w-]/.test(texto[i + marca.length] ?? '')) continue;
+					const etiqueta = etiquetaDesde(texto, i);
+					if (!/[\s:]label\s*=/.test(etiqueta)) {
+						sinEtiqueta.push(`${ruta.split('/src/')[1]} → <${componente}>`);
+					}
+				}
+			}
+		}
+
+		expect(sinEtiqueta).toEqual([]);
+	});
+});

--- a/src/views/ConnectMenuView.vue
+++ b/src/views/ConnectMenuView.vue
@@ -265,7 +265,7 @@ onBeforeUnmount(() => {
 
         <div class="flex items-center justify-between gap-2 text-xs text-tx-muted">
           <span>{{ t('views.connect.showSystem') }}</span>
-          <SwitchToggle :is-on="showSystem" @toggle="showSystem = $event" />
+          <SwitchToggle :label="t('views.connect.showSystem')" :is-on="showSystem" @toggle="showSystem = $event" />
         </div>
       </template>
     </div>

--- a/src/views/ConnectMenuView.vue
+++ b/src/views/ConnectMenuView.vue
@@ -204,8 +204,7 @@ onBeforeUnmount(() => {
           type="button"
           :title="t('views.connect.refresh')"
           @click="loadApps(true)"
-          class="rounded-corner p-2 hover:bg-primary"
-        >
+          class="rounded-corner p-2 hover:bg-primary" :aria-label="t('views.connect.refresh')">
           <img :src="refreshIcon" alt="" class="h-5 w-5" />
         </button>
       </header>
@@ -229,7 +228,7 @@ onBeforeUnmount(() => {
           type="search"
           :placeholder="t('views.connect.search')"
           :aria-label="t('views.connect.search')"
-          class="form-control w-full rounded-corner border border-ui-border bg-ui-bg/80 p-2 shadow-none focus:outline-none focus:ring-0"
+          class="form-control w-full rounded-corner border border-ui-border bg-ui-bg/80 p-2 shadow-none focus:ring-0"
         />
 
         <div v-if="loading" class="flex flex-1 items-center justify-center">

--- a/src/views/MenuView.vue
+++ b/src/views/MenuView.vue
@@ -257,7 +257,7 @@ const onBlur = () => {
                 <CategoryMenuPill
                   :category="categoryEntries.all[0]"
                   :image="categoryEntries.all[1].icon"
-                  :description="t(categoryEntries.all[1].description)"
+                  :label="t(categoryEntries.all[1].description)"
                   v-model:categorySelected="categorySelected"
                   large
                   class="w-full h-full"
@@ -275,7 +275,7 @@ const onBlur = () => {
                   :key="key"
                   :category="key"
                   :image="value.icon"
-                  :description="t(value.description)"
+                  :label="t(value.description)"
                   v-model:categorySelected="categorySelected"
                 />
               </transition-group>

--- a/src/views/apps/SearchView.vue
+++ b/src/views/apps/SearchView.vue
@@ -206,7 +206,7 @@ function getCategoryLabel(category: string): string {
           <input
             v-model="query"
             type="text"
-            class="search-input flex-1 bg-transparent border-none outline-none text-xl text-vsk-text font-medium placeholder:text-vsk-text/30"
+            class="search-input flex-1 bg-transparent border-none text-xl text-vsk-text font-medium placeholder:text-vsk-text/30"
             :placeholder="t('views.search.placeholder')"
             autofocus
           />


### PR DESCRIPTION
Segunda tanda del trabajo de UI/UX, con lo medido en el análisis anterior. Todo esto es común a las nueve interfaces y el bloque de tokens sigue byte a byte idéntico entre ellas.

## 🔴 El foco del teclado era invisible (WCAG 2.4.7)

Medido: **259 botones**, **56** lugares con `outline-none` y sólo **21** con `focus-visible:`. Seis de las ocho aplicaciones no tenían ninguno, así que recorrer con Tab era hacerlo a ciegas.

- Un indicador por omisión en `main.css` para enlaces, botones, campos y cualquier cosa enfocable. Va con `:where()` —especificidad cero— para que un componente que quiera el suyo lo pise sin peleas.
- Se quitan los **52 `outline-none` que no tenían un `focus-visible` al lado**: esos borraban el indicador sin reponer nada. Los 6 que sí definen su propio foco quedan como están.

## 🔴 Cero soporte de `prefers-reduced-motion` (WCAG 2.3.3, y 2.2.2 para lo infinito)

**378 transiciones** y **41 animaciones infinitas** —22 `animate-pulse`, 18 `animate-spin`, 1 `bounce`— sin ninguna forma de apagarlas. Un indicador de «conectando» que pulsa para siempre no lo podía detener nadie.

El bloque no apaga del todo: deja una duración mínima en lugar de `none`, así los eventos `transitionend` y `animationend` siguen llegando —hay código que los espera— y `animation-iteration-count: 1` corta lo infinito, que es la parte que marea.

## 🔴 El texto secundario fallaba en modo claro (WCAG 1.4.3)

```
tx-muted #6c6f85 sobre superficie #ccd0da = 3.20   (mínimo 4.5)
tx-muted #6c6f85 sobre fondo      #eff1f5 = 4.37   (mínimo 4.5)
```

Y es el color de casi todo el texto secundario, que además suele ir en 12px o menos. Pasa a **`#555869`**: 6.22 y 4.56, y sigue más claro que el texto principal, así que la jerarquía se mantiene. El modo oscuro ya cumplía (7.37 y 5.65) y no se toca.

## 🔴 Los bordes no se percibían (WCAG 1.4.11)

`ui-border` da **1.14** contra el fondo en oscuro y **1.17** en claro, contra el mínimo de 3.0 para lo que no es texto: el contorno de un campo no se ve.

Se separa en dos tokens en lugar de subir uno solo, porque el mismo color también hace de separador decorativo y subirlo ahí convertiría cada tarjeta en una caja marcada. `ui-border` se queda sutil y aparece **`ui-border-strong`** —`#6c7086` en oscuro (3.36) y `#7c7f93` en claro (3.49)— para lo que delimita un control.

## 🔴 La barra de desplazamiento era invisible en modo claro

`rgba(255,255,255,.2)`: blanco sobre fondo claro. Ahora sale del token de texto apagado, así que sigue al tema.

## Nombres accesibles: de 69 sin nombre a 28

**81 botones de sólo icono**, y 69 sin nombre accesible. El `title` no cuenta: no lo anuncian todos los lectores, no aparece con teclado y no existe en táctil.

- **22** tenían `title`, donde el nombre ya estaba decidido: se refleja en `aria-label` con la misma forma de enlace.
- **19** se conectaron a la clave de traducción que ya existía al lado —incluidas las siete de la barra del gestor, que tenían `fileBrowser.goBack` y compañía sin usar—.
- **6 eran componentes genéricos** y se resolvieron acá: `SwitchToggle`, `ToggleControl`, `SliderControl`, `CategoryMenuPill` y `AppButton` reciben la etiqueta por prop. En los cuatro primeros es obligatoria —un valor por omisión deja el control muteado sin que nada falle—, y reemplaza al par `alt`+`tooltip` que los consumidores venían pasando duplicado con el mismo texto.
- **22 quedan**, y a propósito: necesitan una etiqueta que habría que inventar, y una etiqueta equivocada le miente al lector de pantalla, que es peor que no tener ninguna.

## Etiquetas de los controles

`aria-pressed` va sólo donde el botón alterna algo de verdad. En el de red abre un panel, y en `ThemeToggle` el `is-active` está fijo en `true` por estilo: ahí el estado de dos posiciones es el modo oscuro, no el resaltado.

El deslizador de volumen y el de brillo no tenían nombre de ninguna clase —un `<input type="range">` suelto, sin `<label>` asociado—: se anunciaban «control deslizante, 40». Ahora dicen qué regulan y leen el porcentaje que se ve al lado.

En `CategoryMenuPill` la prop se llamaba `description` y sólo llegaba al `title` de la imagen; el nombre accesible del botón era el identificador crudo de la categoría, sin traducir.

El pulgar del interruptor era blanco, que mide **1.54** contra la pista apagada del tema claro (`#ccd0da`), por debajo del 3:1 que pide la WCAG 1.4.11 para un elemento cuya posición *es* la información.

## Verificación

Dos pruebas nuevas en `src/tools/etiquetas.test.ts`, las dos comprobadas por mutación —rompiendo una clave y quitando una etiqueta— para que no pasen en vacío: que toda clave literal citada en el código exista en el catálogo, y que ningún control sin texto propio quede sin etiqueta si alguien le pone un valor por omisión a la prop.

`vue-tsc` sin errores en las nueve. CSS compilado: las reglas nuevas están presentes y `--radius-corner-sm`, `--color-tx-on-secondary` y `--color-ui-border-strong` generan sus utilidades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard focus visibility across search, Wi-Fi, Bluetooth, and other interactive controls.
  * Added accessible labels to notification, Bluetooth, refresh, and music controls.
* **Visual Improvements**
  * Added theme-aware strong borders and scrollbar colors.
  * Updated muted text contrast in the light theme.
* **User Experience**
  * Reduced-motion settings now limit animations and disable smooth scrolling for a more comfortable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
