### PR TITLE
fix: el lint vuelve a estar en verde, y el empaquetado deja de saltearse

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["src/**/*"]
+    "includes": ["src/**/*", "!**/*.svg"]
   },
   "formatter": {
     "enabled": true,

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -284,9 +284,13 @@ body * {
   *,
   *::before,
   *::after {
+    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a cualquier animación declarada en otro lado, incluidas las clases de utilidad y los estilos en línea */
     animation-duration: 0.01ms !important;
+    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a cualquier animación declarada en otro lado, incluidas las clases de utilidad y los estilos en línea */
     animation-iteration-count: 1 !important;
+    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a cualquier animación declarada en otro lado, incluidas las clases de utilidad y los estilos en línea */
     transition-duration: 0.01ms !important;
+    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a cualquier animación declarada en otro lado, incluidas las clases de utilidad y los estilos en línea */
     scroll-behavior: auto !important;
   }
 }

--- a/src/tools/etiquetas.test.ts
+++ b/src/tools/etiquetas.test.ts
@@ -16,7 +16,12 @@ const RAIZ_LOCALES = join(import.meta.dir, '../../src-tauri/locales');
 const RAIZ_FUENTE = join(import.meta.dir, '../../src');
 
 /** Controles sin texto propio: el nombre les tiene que llegar por prop. */
-const CON_ETIQUETA_OBLIGATORIA = ['SwitchToggle', 'ToggleControl', 'SliderControl', 'CategoryMenuPill'] as const;
+const CON_ETIQUETA_OBLIGATORIA = [
+	'SwitchToggle',
+	'ToggleControl',
+	'SliderControl',
+	'CategoryMenuPill',
+] as const;
 
 const catalogo = () =>
 	Bun.YAML.parse(readFileSync(join(RAIZ_LOCALES, 'es.yml'), 'utf8')) as Record<string, unknown>;


### PR DESCRIPTION
`check-all.sh` trata cualquier aviso de biome como «esta aplicación no compila», así que estos avisos dejaban al paquete **afuera del repositorio** sin que nada más fallara. Ocho paquetes se saltearon en la última pasada por esto.

## El `!important` del movimiento reducido

Es a propósito y se marca como tal, con el motivo escrito: es la forma canónica de respetar «reducir el movimiento», y tiene que ganarle a cualquier animación declarada en otro lado, incluidas las clases de utilidad y los estilos en línea. Apagar la regla entera hubiera tapado los `!important` que sí conviene mirar.

## Los SVG de `assets`

Salen del alcance de biome: son dibujos, no código. Los estaba parseando como si fueran otra cosa y devolvía errores de sintaxis y avisos de accesibilidad sobre un archivo que nadie escribe a mano.

Verificado: `biome check .` limpio.