### PR TITLE
fix: el motivo del biome-ignore afirmaba de más

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -284,13 +284,13 @@ body * {
   *,
   *::before,
   *::after {
-    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a cualquier animación declarada en otro lado, incluidas las clases de utilidad y los estilos en línea */
+    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a las declaraciones de animación y de transición que no usen `!important`, que son las de las clases de utilidad y las de los componentes */
     animation-duration: 0.01ms !important;
-    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a cualquier animación declarada en otro lado, incluidas las clases de utilidad y los estilos en línea */
+    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a las declaraciones de animación y de transición que no usen `!important`, que son las de las clases de utilidad y las de los componentes */
     animation-iteration-count: 1 !important;
-    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a cualquier animación declarada en otro lado, incluidas las clases de utilidad y los estilos en línea */
+    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a las declaraciones de animación y de transición que no usen `!important`, que son las de las clases de utilidad y las de los componentes */
     transition-duration: 0.01ms !important;
-    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a cualquier animación declarada en otro lado, incluidas las clases de utilidad y los estilos en línea */
+    /* biome-ignore lint/complexity/noImportantStyles: es la forma canónica de respetar «reducir el movimiento»: tiene que ganarle a las declaraciones de animación y de transición que no usen `!important`, que son las de las clases de utilidad y las de los componentes */
     scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
Salió del review de [vasak-resonance#20](https://github.com/Vasak-OS/vasak-resonance/pull/20), y vale para las ocho aplicaciones donde escribí el mismo texto.

Decía que el `!important` del bloque de movimiento reducido le gana a «cualquier animación, incluidos los estilos en línea», y no es cierto:

- En la misma capa, una declaración de autor con `!important` y más especificidad le gana igual.
- Un estilo en línea con `!important` también.
- Y `transition-duration` controla una transición, no una animación.

Pasa a decir lo que sí es verdad: le gana a las declaraciones de animación y de transición **que no usen `!important`**, que son las de las clases de utilidad y las de los componentes.

Sólo cambia el texto del comentario; el CSS queda igual.