### PR TITLE
El clima vuelve a mostrarse

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,7 +13,7 @@
     "enableGTKAppId": true,
     "windows": [],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://api.open-meteo.com; media-src 'self' asset: http://asset.localhost; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://api.open-meteo.com https://geocoding-api.open-meteo.com; media-src 'self' asset: http://asset.localhost; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
       "assetProtocol": {
         "scope": [
           "$HOME/**",

--- a/src/tools/politica-de-contenido.test.ts
+++ b/src/tools/politica-de-contenido.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * La política de contenido y el código tienen que decir lo mismo.
+ *
+ * Un servidor que el código consulta pero la política no nombra no falla al
+ * compilar ni al arrancar: el webview corta el pedido en silencio y lo único
+ * que se ve es el widget diciendo que no pudo. Fue exactamente lo que le pasó
+ * al clima, que geocodifica contra `geocoding-api.open-meteo.com` mientras la
+ * política sólo permitía `api.open-meteo.com`. Este test compara las dos listas
+ * para que la próxima vez el que se olvide sea el test y no quien usa el
+ * escritorio.
+ */
+
+const RAIZ = join(import.meta.dir, '..');
+const CONFIGURACION = join(RAIZ, '..', 'src-tauri', 'tauri.conf.json');
+
+/** Los servidores que `connect-src` deja consultar. */
+function permitidos(): Set<string> {
+	const { app } = JSON.parse(readFileSync(CONFIGURACION, 'utf8'));
+	const csp: string = app.security.csp;
+
+	const directiva = csp
+		.split(';')
+		.map((parte) => parte.trim())
+		.find((parte) => parte.startsWith('connect-src'));
+
+	if (!directiva) throw new Error('La política no tiene connect-src');
+
+	return new Set(
+		directiva
+			.split(/\s+/)
+			.slice(1)
+			.filter((origen) => origen.startsWith('https://'))
+			.map((origen) => origen.replace('https://', ''))
+	);
+}
+
+/** Los servidores que el código nombra, con dónde los nombra. */
+function usados(): Map<string, string[]> {
+	const encontrados = new Map<string, string[]>();
+
+	const recorrer = (carpeta: string) => {
+		for (const entrada of readdirSync(carpeta, { withFileTypes: true })) {
+			const camino = join(carpeta, entrada.name);
+
+			if (entrada.isDirectory()) {
+				recorrer(camino);
+				continue;
+			}
+			if (!/\.(ts|vue)$/.test(entrada.name) || entrada.name.endsWith('.test.ts')) continue;
+
+			// Un servidor vacío —el `https://` suelto de un comentario o de un
+			// `startsWith`— no es nadie a quien se le pida nada.
+			for (const [, servidor] of readFileSync(camino, 'utf8').matchAll(
+				/https:\/\/([a-zA-Z0-9._-]+)/g
+			)) {
+				encontrados.set(servidor, [...(encontrados.get(servidor) ?? []), camino]);
+			}
+		}
+	};
+
+	recorrer(RAIZ);
+	return encontrados;
+}
+
+describe('política de contenido', () => {
+	test('permite todos los servidores que el código consulta', () => {
+		const lista = permitidos();
+		const faltantes = [...usados()]
+			.filter(([servidor]) => !lista.has(servidor))
+			.map(([servidor, archivos]) => `${servidor} (en ${archivos.join(', ')})`);
+
+		expect(faltantes).toEqual([]);
+	});
+
+	test('no permite servidores que nadie consulta', () => {
+		const lista = usados();
+		const sobrantes = [...permitidos()].filter((servidor) => !lista.has(servidor));
+
+		expect(sobrantes).toEqual([]);
+	});
+});

--- a/src/tools/politica-de-contenido.test.ts
+++ b/src/tools/politica-de-contenido.test.ts
@@ -17,6 +17,20 @@ import { join } from 'node:path';
 const RAIZ = join(import.meta.dir, '..');
 const CONFIGURACION = join(RAIZ, '..', 'src-tauri', 'tauri.conf.json');
 
+/**
+ * El servidor de un origen, con su puerto si no es el de siempre.
+ *
+ * Las dos listas tienen que normalizarse igual o la comparación miente en las
+ * dos direcciones: un `:8443` que una lista guarda y la otra descarta hace que
+ * un servidor permitido parezca faltante, y —peor— que un `https://donde:8443`
+ * del código parezca cubierto por un `https://donde` de la política, que en
+ * realidad no lo cubre: la política no acepta un puerto que su origen no
+ * nombra.
+ */
+function normalizarOrigen(origen: string): string {
+	return new URL(origen).host;
+}
+
 /** Los servidores que `connect-src` deja consultar. */
 function permitidos(): Set<string> {
 	const { app } = JSON.parse(readFileSync(CONFIGURACION, 'utf8'));
@@ -34,7 +48,7 @@ function permitidos(): Set<string> {
 			.split(/\s+/)
 			.slice(1)
 			.filter((origen) => origen.startsWith('https://'))
-			.map((origen) => origen.replace('https://', ''))
+			.map(normalizarOrigen)
 	);
 }
 
@@ -54,9 +68,10 @@ function usados(): Map<string, string[]> {
 
 			// Un servidor vacío —el `https://` suelto de un comentario o de un
 			// `startsWith`— no es nadie a quien se le pida nada.
-			for (const [, servidor] of readFileSync(camino, 'utf8').matchAll(
-				/https:\/\/([a-zA-Z0-9._-]+)/g
+			for (const [origen] of readFileSync(camino, 'utf8').matchAll(
+				/https:\/\/[a-zA-Z0-9._-]+(?::\d+)?/g
 			)) {
+				const servidor = normalizarOrigen(origen);
 				encontrados.set(servidor, [...(encontrados.get(servidor) ?? []), camino]);
 			}
 		}
@@ -74,6 +89,14 @@ describe('política de contenido', () => {
 			.map(([servidor, archivos]) => `${servidor} (en ${archivos.join(', ')})`);
 
 		expect(faltantes).toEqual([]);
+	});
+
+	test('un puerto distinto es un servidor distinto', () => {
+		// El puerto de siempre no se escribe, así que las dos formas de nombrar
+		// al mismo servidor tienen que dar lo mismo.
+		expect(normalizarOrigen('https://donde:443')).toBe(normalizarOrigen('https://donde'));
+		// Y uno distinto sí, porque la política tampoco lo da por permitido.
+		expect(normalizarOrigen('https://donde:8443')).not.toBe(normalizarOrigen('https://donde'));
 	});
 
 	test('no permite servidores que nadie consulta', () => {


### PR DESCRIPTION
Los dos widgets de clima del escritorio y el control del panel mostraban siempre «no se pudo obtener el clima».

## Qué pasaba

La política de contenido que estrenó la aplicación en `6141c09` permite `https://api.open-meteo.com` en `connect-src`, pero no `https://geocoding-api.open-meteo.com`. Son dos servidores distintos, y el widget arranca por el segundo: [`deducirLugar()`](src/tools/composables/useWeather.ts) traduce la zona horaria a coordenadas antes de pedir el pronóstico.

El webview corta ese pedido en silencio —no falla al compilar ni al arrancar—, así que nunca se llegaba al pronóstico. Y como las coordenadas se guardan en el cache de Rust recién cuando el pronóstico llega, no había cómo salir del pozo: cada sesión volvía a empezar por el pedido bloqueado.

## Qué cambia

- La política nombra los dos servidores.
- Un test compara las dos listas en las dos direcciones: que la política permita todo lo que el código consulta, y que no permita servidores que ya nadie consulta. Quitando el servidor de la política, el test falla nombrando el archivo que lo usa.

## Verificación

- `bun test`: 31 pass, 0 fail.
- `cargo test`: 92 pass, 0 fail, 2 ignored.
- `bunx biome check`: sin hallazgos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled secure connections to the geocoding service, ensuring location-based features can retrieve address data successfully.

* **Tests**
  * Added automated checks to verify that external services used by the app are permitted by its security policy and remain synchronized over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->