### PR TITLE
Notificaciones que no parpadean, y la tarjeta del usuario

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vasak-desktop",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "engines": {
     "bun": ">=1.2.21"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5856,7 +5856,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vasak-desktop"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vasak-desktop"
-version = "1.3.1"
+version = "1.3.2"
 description = "A Vasak Application (template)"
 authors = ["Vasak Group", "Joaquin (Pato) Decima"]
 edition = "2021"

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -46,15 +46,19 @@ struct FlareNotification {
     read: bool,
 }
 
-// Kept compatible with the frontend's existing `notification-delta` handler.
+/// Lo que va al frontend cada vez que el demonio avisa un cambio.
+///
+/// Es una foto entera, en **un solo** evento, y eso es a propósito. Antes eran
+/// dos —`Cleared` y después `BatchUpdate` con todo de nuevo—, y como cada
+/// `emit` es un mensaje aparte, el frontend alcanzaba a dibujar la lista vacía
+/// entre uno y otro: borrar una sola notificación desmontaba las demás y las
+/// volvía a montar, así que todas repetían la animación de entrada. Con un
+/// evento la lista se reemplaza de una, Vue compara por clave y sólo se anima
+/// lo que de verdad entró o salió.
 #[derive(Serialize, Clone)]
 #[serde(tag = "action", rename_all = "snake_case")]
 enum NotificationDelta {
-    BatchUpdate {
-        added: Vec<Notification>,
-        removed: Vec<u32>,
-    },
-    Cleared,
+    Snapshot { items: Vec<Notification> },
 }
 
 fn map(f: FlareNotification) -> Notification {
@@ -164,8 +168,7 @@ pub async fn send_system_notification(
     Ok("Notification sent".to_string())
 }
 
-/// Fetch the current list and push it to the frontend as a full replace
-/// (Cleared + BatchUpdate), matching the existing delta handler.
+/// Lee la lista actual y la manda entera al frontend, en un solo evento.
 async fn emit_current() {
     let items = match fetch_all().await {
         Ok(v) => v,
@@ -175,14 +178,7 @@ async fn emit_current() {
         }
     };
     if let Some(app) = APP_HANDLE.read().await.as_ref() {
-        let _ = app.emit("notification-delta", NotificationDelta::Cleared);
-        let _ = app.emit(
-            "notification-delta",
-            NotificationDelta::BatchUpdate {
-                added: items,
-                removed: Vec::new(),
-            },
-        );
+        let _ = app.emit("notification-delta", NotificationDelta::Snapshot { items });
     }
 }
 
@@ -238,4 +234,50 @@ pub async fn initialize_app_handle(app_handle: AppHandle) {
             tokio::time::sleep(delay).await;
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn una(id: u32) -> Notification {
+        Notification {
+            id,
+            app_name: "Telegram".into(),
+            app_icon: "telegram".into(),
+            summary: "Hola".into(),
+            body: String::new(),
+            timestamp: 100,
+            seen: false,
+            urgency: NotificationUrgency::Normal,
+            actions: Vec::new(),
+            hints: HashMap::new(),
+        }
+    }
+
+    /// El frontend elige qué hacer mirando `action`, así que el nombre es
+    /// contrato y no un detalle del enum.
+    #[test]
+    fn la_foto_se_serializa_como_snapshot() {
+        let json = serde_json::to_value(NotificationDelta::Snapshot {
+            items: vec![una(1), una(2)],
+        })
+        .expect("la foto se serializa");
+
+        assert_eq!(json["action"], "snapshot");
+        assert_eq!(json["items"].as_array().map(Vec::len), Some(2));
+        assert_eq!(json["items"][0]["id"], 1);
+    }
+
+    /// Vaciar la lista es una foto sin nada adentro, no un evento aparte: es
+    /// justamente el segundo evento el que hacía que las notificaciones
+    /// sobrevivientes repitieran la animación de entrada.
+    #[test]
+    fn vaciar_es_una_foto_vacia() {
+        let json = serde_json::to_value(NotificationDelta::Snapshot { items: Vec::new() })
+            .expect("la foto vacía se serializa");
+
+        assert_eq!(json["action"], "snapshot");
+        assert_eq!(json["items"].as_array().map(Vec::len), Some(0));
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vasak-desktop",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "identifier": "ar.net.vasak.vasak-desktop",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/areas/control-center/NotificationArea.vue
+++ b/src/components/areas/control-center/NotificationArea.vue
@@ -39,7 +39,7 @@
       <p class="mt-1 text-sm">{{ t('components.NotificationArea.empty') }}</p>
     </div>
 
-    <TransitionGroup move-class="transition-transform duration-300 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]" enter-active-class="transition-all duration-400 ease-[cubic-bezier(0.34,1.56,0.64,1)] [&>.notification-item]:animate-pulse-notification" leave-active-class="transition-all duration-300 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]" enter-from-class="opacity-0 translate-x-full scale-90" leave-to-class="opacity-0 translate-x-[-30%] scale-95" tag="div" class="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto overflow-x-hidden pr-1">
+    <TransitionGroup move-class="transition-transform duration-300 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]" enter-active-class="transition-all duration-400 ease-[cubic-bezier(0.34,1.56,0.64,1)]" leave-active-class="transition-all duration-300 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]" enter-from-class="opacity-0 translate-x-full scale-90" leave-to-class="opacity-0 translate-x-[-30%] scale-95" tag="div" class="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto overflow-x-hidden pr-1">
       <NotificationGroupCard
         v-for="group in groupedNotifications"
         :key="group.app_name"
@@ -69,40 +69,16 @@ import {
 } from '@/services/notification.service';
 import { useSymbol } from '@/tools/composables/useReactiveIcon';
 import { useSharedEvent } from '@/tools/event.bus';
+import { agruparNotificaciones } from '@/tools/notificaciones';
 
 const { t } = useI18n();
 
 const notifications = ref<Notification[]>([]);
 const emptyIcon = useSymbol('preferences-desktop-notification');
 
-// Computed para agrupar notificaciones por aplicación
-const groupedNotifications = computed<NotificationGroupData[]>(() => {
-	const groups = new Map<string, NotificationGroupData>();
-
-	notifications.value.forEach((notification) => {
-		const appName = notification.app_name;
-
-		if (!groups.has(appName)) {
-			groups.set(appName, {
-				app_name: appName,
-				app_icon: notification.app_icon,
-				notifications: [],
-				count: 0,
-				latest_timestamp: 0,
-				has_unread: false,
-			});
-		}
-
-		// biome-ignore lint/style/noNonNullAssertion: <Is necessary for dinamic grouping>
-		const group = groups.get(appName)!;
-		group.notifications.push(notification);
-		group.count = group.notifications.length;
-		group.latest_timestamp = Math.max(group.latest_timestamp, notification.timestamp);
-		group.has_unread = group.has_unread || !notification.seen;
-	});
-
-	return Array.from(groups.values()).sort((a, b) => b.latest_timestamp - a.latest_timestamp);
-});
+const groupedNotifications = computed<NotificationGroupData[]>(() =>
+	agruparNotificaciones(notifications.value)
+);
 
 async function loadNotifications() {
 	try {
@@ -133,30 +109,13 @@ onMounted(async () => {
 	await loadNotifications();
 });
 
+// Una foto entera reemplaza la lista de una sola vez. Nada de vaciarla primero:
+// entre el vaciado y el relleno Vue alcanza a dibujar, y las notificaciones que
+// sobrevivían a un borrado se desmontaban y volvían a montarse repitiendo la
+// animación de entrada. Asignando una vez, las claves que siguen estando se
+// reconocen y sólo se anima lo que de verdad entró o salió.
 useSharedEvent<NotificationDelta>('notification-delta', (delta) => {
-	switch (delta.action) {
-		case 'added':
-			notifications.value.unshift(delta.notification);
-			if (delta.dropped_id != null) {
-				notifications.value = notifications.value.filter((n) => n.id !== delta.dropped_id);
-			}
-			break;
-		case 'removed':
-			notifications.value = notifications.value.filter((n) => n.id !== delta.id);
-			break;
-		case 'batch_update':
-			if (delta.added.length > 0) {
-				notifications.value = [...delta.added, ...notifications.value];
-			}
-			if (delta.removed.length > 0) {
-				const removedSet = new Set(delta.removed);
-				notifications.value = notifications.value.filter((n) => !removedSet.has(n.id));
-			}
-			break;
-		case 'cleared':
-			notifications.value = [];
-			break;
-	}
+	notifications.value = delta.items;
 });
 </script>
 

--- a/src/components/cards/UserControlCenterCard.test.ts
+++ b/src/components/cards/UserControlCenterCard.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * La tarjeta del usuario en el centro de control no se puede tocar: muestra
+ * quién sos, la hora y la fecha, y no responde a ningún clic.
+ *
+ * Es la misma decisión que ya se tomó para los iconos de la bandeja —que no se
+ * resalte lo que no se puede tocar—, y volvió a perderse acá: la tarjeta se
+ * pintaba de otro color y se agrandaba al pasar el mouse, prometiendo un botón
+ * que no existe. Se fija en un test porque es una regla de diseño, no un gusto
+ * de una tarde.
+ */
+
+const COMPONENTE = readFileSync(join(import.meta.dir, 'UserControlCenterCard.vue'), 'utf8');
+
+describe('tarjeta del usuario', () => {
+	test('no reacciona al pasar el mouse', () => {
+		const reacciones = [...COMPONENTE.matchAll(/(?:group-)?hover:[a-z0-9:[\]/.-]+/g)].map(
+			([clase]) => clase
+		);
+
+		expect(reacciones).toEqual([]);
+	});
+
+	test('la foto del usuario es un círculo', () => {
+		const foto = COMPONENTE.slice(COMPONENTE.indexOf('<img'), COMPONENTE.indexOf('</div>'));
+
+		// En la imagen, porque no hereda el redondeo del contenedor...
+		expect(foto).toContain('rounded-full');
+		// ...y recortada por la caja, para que un avatar que no sea cuadrado
+		// tampoco se salga.
+		expect(COMPONENTE).toContain('overflow-hidden rounded-full');
+	});
+});

--- a/src/components/cards/UserControlCenterCard.vue
+++ b/src/components/cards/UserControlCenterCard.vue
@@ -1,18 +1,25 @@
 <template>
+  <!-- Sin reacción al pasar el mouse: la tarjeta no se puede tocar. Cambiaba de
+       fondo, se agrandaba y le pintaba el nombre de otro color a algo que no
+       hace nada al hacerle clic, así que prometía un botón que no existe. Es la
+       misma decisión que en los iconos de la bandeja: que no se resalte lo que
+       no se puede tocar. -->
   <div
-    class="bg-ui-bg/80 rounded-corner border border-ui-border p-4 flex items-center gap-4 w-full transition-all duration-300 hover:bg-secondary hover:scale-[1.02] group"
+    class="bg-ui-bg/80 rounded-corner border border-ui-border p-4 flex items-center gap-4 w-full transition-all duration-300"
     :class="{
       'opacity-0 translate-y-4': !isLoaded,
       'opacity-100 translate-y-0': isLoaded,
     }"
   >
-    <div
-      class="relative w-16 h-16 rounded-full transition-all duration-300 group-hover:scale-110 "
-    >
+    <!-- El redondeo va también en la imagen, y el recorte en la caja: el
+         `rounded-full` estaba sólo acá afuera, y como la imagen no hereda el
+         redondeo de su contenedor ni lo desborda, la foto se veía cuadrada
+         dentro de un círculo que no recortaba nada. -->
+    <div class="relative w-16 h-16 shrink-0 overflow-hidden rounded-full">
       <img
         :src="userInfo.avatar_data"
         :alt="userInfo.full_name"
-        class="h-full w-full aspect-square object-cover transition-all duration-300 "
+        class="h-full w-full aspect-square rounded-full object-cover transition-all duration-300"
         :class="{
           'opacity-0 scale-90': !isLoaded,
           'opacity-100 scale-100': isLoaded,
@@ -22,12 +29,12 @@
     </div>
     <div class="flex flex-col flex-1 space-y-1">
       <h2
-        class="text-lg font-semibold transition-all duration-300 group-hover:text-primary"
+        class="text-lg font-semibold"
       >
         {{ userInfo.full_name }}
       </h2>
       <p
-        class="text-sm text-tx-muted transition-all duration-500 group-hover:opacity-90"
+        class="text-sm text-tx-muted"
       >
         {{ userInfo.username }}
       </p>

--- a/src/interfaces/notifications.ts
+++ b/src/interfaces/notifications.ts
@@ -20,8 +20,14 @@ export interface NotificationGroupData {
 	has_unread: boolean;
 }
 
-export type NotificationDelta =
-	| { action: 'added'; notification: Notification; dropped_id: number | null }
-	| { action: 'removed'; id: number }
-	| { action: 'batch_update'; added: Notification[]; removed: number[] }
-	| { action: 'cleared' };
+/**
+ * Lo que manda Rust cuando el demonio avisa un cambio: la lista entera, en un
+ * solo evento.
+ *
+ * Eran cuatro formas —`added`, `removed`, `batch_update`, `cleared`—, pero la
+ * única que se emitía era `cleared` seguida de un `batch_update` con todo de
+ * nuevo. Como son dos eventos, la lista quedaba vacía entre uno y otro y
+ * borrar una notificación hacía que las demás repitieran la animación de
+ * entrada. Con una sola foto se reemplaza de una sola vez.
+ */
+export type NotificationDelta = { action: 'snapshot'; items: Notification[] };

--- a/src/tools/notificaciones.test.ts
+++ b/src/tools/notificaciones.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+import type { Notification } from '@/interfaces/notifications';
+import { agruparNotificaciones, hayNotificacionesNuevas } from '@/tools/notificaciones';
+
+function notificacion(parcial: Partial<Notification> & { id: number }): Notification {
+	return {
+		app_name: 'Telegram',
+		app_icon: 'telegram',
+		summary: 'Hola',
+		body: '',
+		timestamp: 100,
+		seen: false,
+		...parcial,
+	};
+}
+
+describe('agruparNotificaciones', () => {
+	test('junta por aplicación y cuenta', () => {
+		const grupos = agruparNotificaciones([
+			notificacion({ id: 1 }),
+			notificacion({ id: 2, app_name: 'Correo', timestamp: 50 }),
+			notificacion({ id: 3 }),
+		]);
+
+		expect(grupos.map((g) => [g.app_name, g.count])).toEqual([
+			['Telegram', 2],
+			['Correo', 1],
+		]);
+	});
+
+	test('ordena por la notificación más reciente de cada grupo', () => {
+		const grupos = agruparNotificaciones([
+			notificacion({ id: 1, app_name: 'Vieja', timestamp: 10 }),
+			notificacion({ id: 2, app_name: 'Nueva', timestamp: 900 }),
+		]);
+
+		expect(grupos.map((g) => g.app_name)).toEqual(['Nueva', 'Vieja']);
+	});
+
+	test('un grupo está sin leer si le queda alguna sin ver', () => {
+		const [grupo] = agruparNotificaciones([
+			notificacion({ id: 1, seen: true }),
+			notificacion({ id: 2, seen: false }),
+		]);
+
+		expect(grupo.has_unread).toBe(true);
+		expect(grupo.latest_timestamp).toBe(100);
+	});
+
+	/**
+	 * Lo que hace que la lista no parpadee: borrar una notificación no puede
+	 * cambiar la clave de los grupos que sobreviven, porque es lo que Vue mira
+	 * para saber cuáles ya estaban dibujados.
+	 */
+	test('borrar una notificación no cambia la clave de los grupos que quedan', () => {
+		const todas = [
+			notificacion({ id: 1 }),
+			notificacion({ id: 2 }),
+			notificacion({ id: 3, app_name: 'Correo', timestamp: 50 }),
+		];
+
+		const antes = agruparNotificaciones(todas).map((g) => g.app_name);
+		const despues = agruparNotificaciones(todas.filter((n) => n.id !== 2)).map((g) => g.app_name);
+
+		expect(despues).toEqual(antes);
+	});
+
+	test('una aplicación sin notificaciones desaparece de la lista', () => {
+		const todas = [notificacion({ id: 1 }), notificacion({ id: 2, app_name: 'Correo' })];
+		const grupos = agruparNotificaciones(todas.filter((n) => n.app_name !== 'Correo'));
+
+		expect(grupos.map((g) => g.app_name)).toEqual(['Telegram']);
+	});
+
+	test('sin notificaciones no hay grupos', () => {
+		expect(agruparNotificaciones([])).toEqual([]);
+	});
+});
+
+describe('hayNotificacionesNuevas', () => {
+	test('una que no estaba antes cuenta como nueva', () => {
+		const previas = [notificacion({ id: 1 })];
+		expect(hayNotificacionesNuevas(previas, [notificacion({ id: 2 }), ...previas])).toBe(true);
+	});
+
+	/** El caso que hacía sonar la campanita al borrar: la foto trae lo que quedó. */
+	test('borrar una no deja ninguna nueva', () => {
+		const previas = [notificacion({ id: 1 }), notificacion({ id: 2 })];
+		expect(hayNotificacionesNuevas(previas, [notificacion({ id: 1 })])).toBe(false);
+	});
+
+	test('la misma lista no trae nada nuevo', () => {
+		const previas = [notificacion({ id: 1 }), notificacion({ id: 2 })];
+		expect(hayNotificacionesNuevas(previas, [...previas])).toBe(false);
+	});
+
+	test('vaciarlas todas no trae nada nuevo', () => {
+		expect(hayNotificacionesNuevas([notificacion({ id: 1 })], [])).toBe(false);
+	});
+
+	test('la primera notificación de la sesión es nueva', () => {
+		expect(hayNotificacionesNuevas([], [notificacion({ id: 1 })])).toBe(true);
+	});
+});

--- a/src/tools/notificaciones.ts
+++ b/src/tools/notificaciones.ts
@@ -1,0 +1,56 @@
+import type { Notification, NotificationGroupData } from '@/interfaces/notifications';
+
+/**
+ * Las notificaciones agrupadas por aplicación, de la más reciente a la más
+ * vieja.
+ *
+ * La clave del grupo es el nombre de la aplicación, y de eso depende que la
+ * lista no parpadee: es lo que Vue compara para saber qué grupo ya estaba
+ * dibujado. Mientras la aplicación siga teniendo notificaciones, su tarjeta es
+ * la misma aunque el objeto que la describe sea nuevo.
+ */
+export function agruparNotificaciones(
+	notificaciones: readonly Notification[]
+): NotificationGroupData[] {
+	const grupos = new Map<string, NotificationGroupData>();
+
+	for (const notificacion of notificaciones) {
+		const aplicacion = notificacion.app_name;
+		let grupo = grupos.get(aplicacion);
+
+		if (!grupo) {
+			grupo = {
+				app_name: aplicacion,
+				app_icon: notificacion.app_icon,
+				notifications: [],
+				count: 0,
+				latest_timestamp: 0,
+				has_unread: false,
+			};
+			grupos.set(aplicacion, grupo);
+		}
+
+		grupo.notifications.push(notificacion);
+		grupo.count = grupo.notifications.length;
+		grupo.latest_timestamp = Math.max(grupo.latest_timestamp, notificacion.timestamp);
+		grupo.has_unread = grupo.has_unread || !notificacion.seen;
+	}
+
+	return [...grupos.values()].sort((a, b) => b.latest_timestamp - a.latest_timestamp);
+}
+
+/**
+ * Si la foto que llegó trae alguna notificación que antes no estaba.
+ *
+ * El panel sacude la campanita cuando llega algo, y con esto sabe cuándo. Antes
+ * se guiaba por «vino una lista con cosas adentro», que es verdad en toda foto:
+ * la campanita se sacudía también al **borrar** una notificación, porque las
+ * que quedaban llegaban igual en el mismo evento.
+ */
+export function hayNotificacionesNuevas(
+	previas: readonly Notification[],
+	siguientes: readonly Notification[]
+): boolean {
+	const conocidas = new Set(previas.map((n) => n.id));
+	return siguientes.some((n) => !conocidas.has(n.id));
+}

--- a/src/views/PanelView.vue
+++ b/src/views/PanelView.vue
@@ -20,6 +20,7 @@ import { getAllNotifications } from '@/services/notification.service';
 import { toggleControlCenter, toggleMenu } from '@/services/window.service';
 import { useIcons } from '@/tools/composables/useReactiveIcon';
 import { useSharedEvent } from '@/tools/event.bus';
+import { hayNotificacionesNuevas } from '@/tools/notificaciones';
 import { logError } from '@/utils/logger';
 
 const { t } = useI18n();
@@ -185,42 +186,22 @@ useSharedEvent('connect-device-added', refreshConnectDevices);
 useSharedEvent('connect-device-changed', refreshConnectDevices);
 useSharedEvent('connect-device-removed', refreshConnectDevices);
 
+// La foto entera, en una sola asignación: ver `NotificationDelta`.
+//
+// La campanita se sacude sólo si en la foto viene alguna notificación que antes
+// no estaba. Antes bastaba con que la lista trajera algo, y como toda foto trae
+// lo que quedó, la campanita se sacudía también al borrar una.
 useSharedEvent<NotificationDelta>('notification-delta', (delta) => {
-	switch (delta.action) {
-		case 'added':
-			notifications.value.unshift(delta.notification);
-			if (delta.dropped_id != null) {
-				notifications.value = notifications.value.filter((n) => n.id !== delta.dropped_id);
-			}
-			hasNewNotifications.value = true;
-			clearTimeout(notificationResetTimer);
-			notificationResetTimer = setTimeout(() => {
-				hasNewNotifications.value = false;
-			}, 1000);
-			break;
-		case 'removed':
-			notifications.value = notifications.value.filter((n) => n.id !== delta.id);
-			break;
-		case 'batch_update':
-			if (delta.added.length > 0) {
-				notifications.value = [...delta.added, ...notifications.value];
-			}
-			if (delta.removed.length > 0) {
-				const removedSet = new Set(delta.removed);
-				notifications.value = notifications.value.filter((n) => !removedSet.has(n.id));
-			}
-			if (delta.added.length > 0) {
-				hasNewNotifications.value = true;
-				clearTimeout(notificationResetTimer);
-				notificationResetTimer = setTimeout(() => {
-					hasNewNotifications.value = false;
-				}, 1000);
-			}
-			break;
-		case 'cleared':
-			notifications.value = [];
-			break;
-	}
+	const nuevas = hayNotificacionesNuevas(notifications.value, delta.items);
+	notifications.value = delta.items;
+
+	if (!nuevas) return;
+
+	hasNewNotifications.value = true;
+	clearTimeout(notificationResetTimer);
+	notificationResetTimer = setTimeout(() => {
+		hasNewNotifications.value = false;
+	}, 1000);
 });
 </script>
 


### PR DESCRIPTION
Dos problemas visuales del centro de control, sin relación entre sí más allá de estar en la misma ventana.

## 1. Borrar una notificación reiniciaba a todas las demás

`emit_current()` mandaba **dos** eventos por cada cambio: `Cleared` y, acto seguido, un `BatchUpdate` con la lista entera de nuevo. Cada `emit` es un mensaje IPC aparte, así que el frontend alcanzaba a dibujar la lista vacía entre uno y otro —`case 'cleared'` hacía `notifications.value = []`—. Las notificaciones que sobrevivían al borrado se desmontaban y volvían a montarse, y el `TransitionGroup` les corría la animación de entrada a todas.

Ahora el evento es una sola foto, `Snapshot { items }`, y el frontend la asigna de una vez. Las claves que siguen estando (`app_name` en los grupos, `id` en las notificaciones) se reconocen, Vue compara, y sólo se anima lo que de verdad entró o salió.

Las otras tres variantes del protocolo —`added`, `removed`, `batch_update`— no las emitía nadie: se van con el arreglo en vez de quedar sugiriendo un protocolo que no existe.

**Efecto secundario que también se arregla**: la campanita del panel se sacudía cuando `added.length > 0`, y toda foto trae lo que quedó — así que se sacudía al **borrar** una notificación. Ahora se fija si viene alguna que antes no estaba.

## 2. La tarjeta del usuario

- **El hover**: no se le puede hacer clic, pero cambiaba de fondo (`hover:bg-secondary`), se agrandaba y le pintaba el nombre de otro color. Quité toda la reacción, siguiendo la decisión que ya estaba tomada en `bugfix/hover-sin-accion` (#32), «que no se resalte lo que no se puede tocar».
- **La foto**: el `rounded-full` estaba sólo en el `div` contenedor, que no recortaba nada, y la imagen no hereda el redondeo de su contenedor — se veía cuadrada. Ahora el redondeo va también en el `<img>` y la caja recorta, así que un avatar que no sea cuadrado tampoco se sale del círculo.

## Tests

- `tools/notificaciones.ts`: salen ahí la agrupación y la comparación de fotos, que son de lo que depende que la lista no parpadee, con 11 tests — incluido el que fija que borrar una notificación no cambia la clave de los grupos que quedan, y el que fija que una foto tras un borrado no cuenta como «llegó algo nuevo».
- Rust: dos tests del contrato del evento (`action: "snapshot"`), porque el frontend despacha por ese nombre.
- `UserControlCenterCard.test.ts`: fija que la tarjeta no declara ninguna clase `hover:` y que la foto es un círculo. Es una regla de diseño que ya se había perdido una vez.

Verifiqué que los tests nuevos fallan contra el código viejo.

## Verificación

- `bun test`: 45 pass, 0 fail.
- `vue-tsc --noEmit`: limpio.
- `cargo test`: 98 pass, 0 fail, 2 ignored. `cargo clippy --all-targets`: sin avisos.
- `biome check`: limpio.

No lo probé corriendo el escritorio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved notification updates by synchronizing the complete notification list in a single event.
  * Notifications are now grouped by application, sorted by recency, and marked for unread status.
  * The notification bell animation appears only when genuinely new notifications arrive.
  * User control center cards no longer display hover effects, and profile images are consistently circular.

* **Bug Fixes**
  * Improved notification clearing and replacement behavior.
  * Removed unnecessary visual emphasis from non-clickable cards.

* **Tests**
  * Added coverage for notification grouping, new-notification detection, event snapshots, and card styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->