### PR TITLE
El menú respeta las entradas del usuario, y uuctl sale de la lista

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vasak-desktop",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "engines": {
     "bun": ">=1.2.21"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5856,7 +5856,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vasak-desktop"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vasak-desktop"
-version = "1.3.2"
+version = "1.3.3"
 description = "A Vasak Application (template)"
 authors = ["Vasak Group", "Joaquin (Pato) Decima"]
 edition = "2021"

--- a/src-tauri/src/menu_manager.rs
+++ b/src-tauri/src/menu_manager.rs
@@ -46,33 +46,66 @@ pub fn invalidate_menu_cache() {
     }
 }
 
-fn get_applications_dirs() -> Vec<PathBuf> {
+/// Lo que usa XDG cuando `XDG_DATA_DIRS` no dice nada.
+const DATA_DIRS_POR_OMISION: &str = "/usr/local/share:/usr/share";
+
+/// Los directorios de entradas `.desktop`, **del que más manda al que menos**.
+///
+/// El orden no es cosmético: `get_menu` se queda con la primera entrada de cada
+/// nombre de archivo, así que quien vaya primero le gana a los demás. Y estaba
+/// al revés —el directorio de quien usa el sistema iba último—, de modo que un
+/// `~/.local/share/applications/loquesea.desktop` puesto para cambiarle el
+/// nombre, el icono o el comando a una aplicación quedaba tapado por el del
+/// sistema y no hacía nada. La especificación XDG dice lo contrario:
+/// `XDG_DATA_HOME` manda sobre `XDG_DATA_DIRS`.
+///
+/// De paso se respeta `XDG_DATA_HOME` en vez de dar por sentado
+/// `~/.local/share`, y el orden de la lista por omisión, que también estaba
+/// invertido: `/usr/local/share` va antes que `/usr/share`.
+fn ordenar_directorios(
+    data_home: Option<String>,
+    home: Option<PathBuf>,
+    data_dirs: Option<String>,
+) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
-    if let Ok(data_dirs) = std::env::var("XDG_DATA_DIRS") {
-        for dir in data_dirs.split(':') {
-            let apps_dir = PathBuf::from(dir).join("applications");
-            if apps_dir.exists() {
-                dirs.push(apps_dir);
-            }
-        }
-    } else {
-        for dir in &["/usr/share", "/usr/local/share"] {
-            let apps_dir = PathBuf::from(dir).join("applications");
-            if apps_dir.exists() {
-                dirs.push(apps_dir);
-            }
-        }
+    let base_del_usuario = data_home
+        .filter(|valor| !valor.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| home.map(|casa| casa.join(".local/share")));
+
+    if let Some(base) = base_del_usuario {
+        dirs.push(base.join("applications"));
     }
 
-    if let Some(home) = dirs::home_dir() {
-        let user_apps = home.join(".local/share/applications");
-        if user_apps.exists() {
-            dirs.push(user_apps);
+    // Una variable definida pero vacía significa «usá lo de siempre», igual que
+    // si no estuviera.
+    let del_sistema = data_dirs.filter(|valor| !valor.is_empty());
+
+    for dir in del_sistema
+        .as_deref()
+        .unwrap_or(DATA_DIRS_POR_OMISION)
+        .split(':')
+        .filter(|dir| !dir.is_empty())
+    {
+        let apps_dir = PathBuf::from(dir).join("applications");
+        if !dirs.contains(&apps_dir) {
+            dirs.push(apps_dir);
         }
     }
 
     dirs
+}
+
+fn get_applications_dirs() -> Vec<PathBuf> {
+    ordenar_directorios(
+        std::env::var("XDG_DATA_HOME").ok(),
+        dirs::home_dir(),
+        std::env::var("XDG_DATA_DIRS").ok(),
+    )
+    .into_iter()
+    .filter(|dir| dir.exists())
+    .collect()
 }
 
 /// Session locale, most specific first: `es_AR.UTF-8` yields `es_AR` and `es`.
@@ -268,5 +301,111 @@ fn get_category_description(category: &str) -> String {
         format!("menu.categories.{}", category)
     } else {
         "menu.categories.other".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn apps(base: &str) -> PathBuf {
+        PathBuf::from(base).join("applications")
+    }
+
+    /// El caso que estaba al revés: una entrada del usuario tiene que ganarle a
+    /// la del sistema, porque `get_menu` se queda con la primera de cada
+    /// nombre.
+    #[test]
+    fn el_directorio_del_usuario_va_primero() {
+        let dirs = ordenar_directorios(
+            None,
+            Some(PathBuf::from("/home/alguien")),
+            Some("/usr/local/share:/usr/share".into()),
+        );
+
+        assert_eq!(dirs.first(), Some(&apps("/home/alguien/.local/share")));
+    }
+
+    #[test]
+    fn se_respeta_el_orden_de_xdg_data_dirs() {
+        let dirs = ordenar_directorios(
+            None,
+            Some(PathBuf::from("/home/alguien")),
+            Some("/primero:/segundo:/tercero".into()),
+        );
+
+        assert_eq!(
+            dirs,
+            vec![
+                apps("/home/alguien/.local/share"),
+                apps("/primero"),
+                apps("/segundo"),
+                apps("/tercero"),
+            ]
+        );
+    }
+
+    #[test]
+    fn xdg_data_home_le_gana_a_la_carpeta_de_siempre() {
+        let dirs = ordenar_directorios(
+            Some("/otro/lado".into()),
+            Some(PathBuf::from("/home/alguien")),
+            Some("/usr/share".into()),
+        );
+
+        assert_eq!(dirs.first(), Some(&apps("/otro/lado")));
+        assert!(!dirs.contains(&apps("/home/alguien/.local/share")));
+    }
+
+    /// Una variable definida pero vacía es lo mismo que no tenerla: es lo que
+    /// dice la especificación, y si no `"".split(':')` metía un directorio
+    /// llamado `applications` colgando de la raíz.
+    #[test]
+    fn una_variable_vacia_es_como_no_tenerla() {
+        let con_vacias = ordenar_directorios(
+            Some(String::new()),
+            Some(PathBuf::from("/home/alguien")),
+            Some(String::new()),
+        );
+        let sin_ellas = ordenar_directorios(None, Some(PathBuf::from("/home/alguien")), None);
+
+        assert_eq!(con_vacias, sin_ellas);
+        assert!(!con_vacias.contains(&apps("")));
+    }
+
+    /// `/usr/local/share` antes que `/usr/share`, que es el orden de XDG. La
+    /// lista de reserva los tenía al revés.
+    #[test]
+    fn la_lista_de_reserva_sigue_el_orden_de_xdg() {
+        let dirs = ordenar_directorios(None, Some(PathBuf::from("/home/alguien")), None);
+
+        assert_eq!(
+            dirs,
+            vec![
+                apps("/home/alguien/.local/share"),
+                apps("/usr/local/share"),
+                apps("/usr/share"),
+            ]
+        );
+    }
+
+    #[test]
+    fn sin_casa_quedan_solo_los_del_sistema() {
+        let dirs = ordenar_directorios(None, None, Some("/usr/share".into()));
+
+        assert_eq!(dirs, vec![apps("/usr/share")]);
+    }
+
+    /// Un directorio repetido en `XDG_DATA_DIRS` no puede aparecer dos veces:
+    /// no cambia qué gana, pero hace que cada entrada de ahí se lea dos veces.
+    #[test]
+    fn no_se_repiten_directorios() {
+        let dirs = ordenar_directorios(
+            Some("/casa".into()),
+            None,
+            Some("/casa:/usr/share:/usr/share".into()),
+        );
+
+        assert_eq!(dirs, vec![apps("/casa"), apps("/usr/share")]);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vasak-desktop",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "identifier": "ar.net.vasak.vasak-desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Sale de una pregunta: `uuctl` aparecía en el menú y no hacía nada al hacerle clic.

## Qué es uuctl y por qué estaba

Un selector de unidades de systemd del usuario que instala `uwsm`. `uwsm` hace falta —`vasak-session` lo ejecuta y `wayfire.ini` lo llama con `uwsm finalize`—, pero su herramienta no es de VasakOS y acá ni siquiera funciona: necesita un menú tipo dmenu (fuzzel, wofi, rofi, bemenu…) y no viene ninguno. Corriéndolo a mano:

```
/usr/bin/uuctl: línea 239: dmenu: orden no encontrada
Cancelled
```

Con `Terminal=false` en su `.desktop`, desde el menú eso no se ve: el clic no hace absolutamente nada.

## El bug que apareció al querer taparlo

La forma natural de esconder una entrada de otro paquete es un `.desktop` con `NoDisplay=true` en `~/.local/share/applications`. No servía, y por un defecto de este repo.

`get_menu` se queda con **la primera** entrada de cada nombre de archivo, y `get_applications_dirs` ponía el directorio del usuario **al final**. Así que `/usr/share/applications` le ganaba siempre. La especificación XDG dice lo contrario: `XDG_DATA_HOME` manda sobre `XDG_DATA_DIRS`.

El alcance va más allá de uuctl: quien pusiera un `.desktop` propio para cambiarle el nombre, el icono o el comando a cualquier aplicación no veía ningún efecto en el menú de VasakOS.

De paso, dos cosas más en la misma función:

- `XDG_DATA_HOME` no se miraba; se daba por sentado `~/.local/share`.
- La lista de reserva era `/usr/share:/usr/local/share`, también al revés de lo que dice XDG.

## Tests

El orden sale a `ordenar_directorios`, que recibe las tres variables y devuelve la lista, sin tocar el entorno ni el disco. 7 tests: el directorio del usuario primero, el orden de `XDG_DATA_DIRS`, `XDG_DATA_HOME` ganándole a `~/.local/share`, variables vacías tratadas como ausentes, el orden de la lista de reserva, sin `HOME`, y directorios repetidos.

## Lo que falta del otro lado

Ocultar uuctl es un archivo en `vasak-desktop-settings` (`/etc/skel/.local/share/applications/uuctl.desktop` con `NoDisplay=true`), que va por su propio repo y ya declara `vasak-desktop>=1.3.3` en el PKGBUILD, porque sin este arreglo no taparía nada.

## Verificación

- `cargo test`: 101 pass, 0 fail, 2 ignored. `cargo clippy --all-targets`: sin avisos.
- `bun test`: 45 pass. `biome check` y `vue-tsc --noEmit`: limpios.

No lo probé corriendo el escritorio.