### PR TITLE
La cámara del teléfono se prende desde el centro de control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vasak-desktop",
   "private": true,
-  "version": "1.3.3",
+  "version": "1.4.0",
   "type": "module",
   "engines": {
     "bun": ">=1.2.21"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5856,7 +5856,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vasak-desktop"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vasak-desktop"
-version = "1.3.3"
+version = "1.4.0"
 description = "A Vasak Application (template)"
 authors = ["Vasak Group", "Joaquin (Pato) Decima"]
 edition = "2021"

--- a/src-tauri/locales/en.yml
+++ b/src-tauri/locales/en.yml
@@ -73,6 +73,13 @@ views:
     close: Close
     openApps: "{0} running"
     connecting: Connecting…
+    webcam: Use the camera as a webcam
+    webcamHint: Turn it on before opening the video call.
+    webcamActive: "On · {0}"
+    webcamWorking: One moment…
+    webcamNoModule: The v4l2loopback module is missing. If you updated the kernel, restart.
+    webcamBusy: Another phone is using it.
+    webcamNoCameras: The phone reported no cameras.
   panel:
     menuAlt: Menu
     settingsAlt: Settings

--- a/src-tauri/locales/es.yml
+++ b/src-tauri/locales/es.yml
@@ -73,6 +73,13 @@ views:
     close: Cerrar
     openApps: "{0} en ejecución"
     connecting: Conectando…
+    webcam: Usar la cámara como webcam
+    webcamHint: Prendela antes de abrir la videollamada.
+    webcamActive: "Encendida · {0}"
+    webcamWorking: Un momento…
+    webcamNoModule: Falta el módulo v4l2loopback. Si actualizaste el kernel, reiniciá.
+    webcamBusy: La está usando otro teléfono.
+    webcamNoCameras: El teléfono no informó ninguna cámara.
   panel:
     menuAlt: Menú
     settingsAlt: Configuración

--- a/src-tauri/src/connect.rs
+++ b/src-tauri/src/connect.rs
@@ -50,6 +50,41 @@ pub struct ConnectApp {
     pub icon: String,
 }
 
+/// A camera on a phone.
+///
+/// `sizes` and `fps` come from the sensor, not from a list of common modes:
+/// asking for a mode the camera does not have is how the stream opens and dies
+/// half a second later.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct ConnectCamera {
+    /// scrcpy's camera id. Opaque, and only unique within one phone.
+    pub id: String,
+    /// `back`, `front` or `external`. The only thing that tells a person which
+    /// camera they are picking — an id of `0` or `2` means nothing to anybody.
+    pub facing: String,
+    /// Capture sizes the sensor accepts, largest first, as `1280x720`.
+    pub sizes: Vec<String>,
+    pub fps: Vec<u32>,
+}
+
+/// What the webcam bridge is doing.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Type)]
+pub struct ConnectWebcamState {
+    pub active: bool,
+    /// The device other applications open, e.g. `/dev/video42`.
+    ///
+    /// Empty means the v4l2loopback module is not loaded. That is reported
+    /// outside `active` because it is the one failure a person can fix, and
+    /// they need to see it *before* pressing anything.
+    pub device: String,
+    /// Which phone is feeding it. Empty unless `active`.
+    pub serial: String,
+    /// Empty unless `active`.
+    pub camera_id: String,
+    /// Empty unless `active`.
+    pub size: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct ConnectRunningApp {
     pub serial: String,
@@ -142,6 +177,62 @@ pub async fn connect_list_running(app: AppHandle) -> Vec<ConnectRunningApp> {
         .unwrap_or_default()
 }
 
+/// The cameras a phone has.
+///
+/// Cached by the daemon after the first call, like the app list. `refresh`
+/// forces it to ask the phone again.
+#[tauri::command]
+pub async fn connect_list_cameras(
+    app: AppHandle,
+    serial: String,
+    refresh: bool,
+) -> Result<Vec<ConnectCamera>, String> {
+    call(&app, "ListCameras", &(serial, refresh)).await
+}
+
+/// Starts writing a phone camera into the loopback device.
+///
+/// Returns the device path other applications should open. `size` may be empty
+/// and `fps` zero to let the phone choose; anything else should come from
+/// [`connect_list_cameras`].
+///
+/// The error is passed through instead of swallowed, unlike the listing
+/// commands: this one runs because somebody pressed a switch, and a switch that
+/// silently goes back to off is the worst of the three possible outcomes.
+#[tauri::command]
+pub async fn connect_start_webcam(
+    app: AppHandle,
+    serial: String,
+    camera_id: String,
+    size: String,
+    fps: u32,
+) -> Result<String, String> {
+    call(&app, "StartWebcam", &(serial, camera_id, size, fps)).await
+}
+
+/// Stops the stream. `false` means there was nothing streaming.
+#[tauri::command]
+pub async fn connect_stop_webcam(app: AppHandle) -> Result<bool, String> {
+    call::<(), bool>(&app, "StopWebcam", &()).await
+}
+
+/// What the webcam bridge is doing, and whether it could run at all.
+///
+/// Falls back to the default — inactive, no device — when the service cannot be
+/// reached, which is the same shape as "the module is not loaded". The panel
+/// only asks while a phone is visible, and a phone is only visible when the
+/// daemon is running, so the two cases cannot be confused in practice.
+#[tauri::command]
+pub async fn connect_webcam_state(app: AppHandle) -> ConnectWebcamState {
+    match call::<(), ConnectWebcamState>(&app, "WebcamState", &()).await {
+        Ok(state) => state,
+        Err(err) => {
+            logger::log_info(&format!("vasak-connect: no se pudo leer el estado de la webcam: {err}"));
+            ConnectWebcamState::default()
+        }
+    }
+}
+
 /// Forwards the service's signals to the panel as Tauri events.
 ///
 /// Without this the panel would have to poll to notice a phone, which is the
@@ -204,6 +295,15 @@ pub async fn watch_signals(app: AppHandle) -> Result<(), Box<dyn std::error::Err
                     if let Ok((serial, package)) = message.body().deserialize::<(String, String)>()
                     {
                         let _ = app.emit("connect-app-closed", (serial, package));
+                    }
+                }
+                // The stream can stop without anybody asking: the phone locks,
+                // or one of its own apps takes the camera. A switch left
+                // showing "on" after that is worse than no switch, because the
+                // person believes there is a camera feeding the call.
+                "WebcamChanged" => {
+                    if let Ok(state) = message.body().deserialize::<ConnectWebcamState>() {
+                        let _ = app.emit("connect-webcam-changed", state);
                     }
                 }
                 _ => {}

--- a/src-tauri/src/connect.rs
+++ b/src-tauri/src/connect.rs
@@ -68,7 +68,7 @@ pub struct ConnectCamera {
 }
 
 /// What the webcam bridge is doing.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct ConnectWebcamState {
     pub active: bool,
     /// The device other applications open, e.g. `/dev/video42`.
@@ -218,19 +218,15 @@ pub async fn connect_stop_webcam(app: AppHandle) -> Result<bool, String> {
 
 /// What the webcam bridge is doing, and whether it could run at all.
 ///
-/// Falls back to the default — inactive, no device — when the service cannot be
-/// reached, which is the same shape as "the module is not loaded". The panel
-/// only asks while a phone is visible, and a phone is only visible when the
-/// daemon is running, so the two cases cannot be confused in practice.
+/// **The error is passed through**, unlike the listing commands. For those, "no
+/// service" and "nothing to show" are the same empty list. Here they are not:
+/// the default state carries an empty `device`, and an empty `device` already
+/// means something specific — the v4l2loopback module is not loaded, fix it with
+/// a `modprobe` or a reboot. Returning it for a call that merely failed sends
+/// somebody to reboot over a D-Bus timeout.
 #[tauri::command]
-pub async fn connect_webcam_state(app: AppHandle) -> ConnectWebcamState {
-    match call::<(), ConnectWebcamState>(&app, "WebcamState", &()).await {
-        Ok(state) => state,
-        Err(err) => {
-            logger::log_info(&format!("vasak-connect: no se pudo leer el estado de la webcam: {err}"));
-            ConnectWebcamState::default()
-        }
-    }
+pub async fn connect_webcam_state(app: AppHandle) -> Result<ConnectWebcamState, String> {
+    call::<(), ConnectWebcamState>(&app, "WebcamState", &()).await
 }
 
 /// Forwards the service's signals to the panel as Tauri events.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,8 +62,9 @@ mod windows_apps;
 use tauri::{Listener, Manager};
 use commands::*;
 use connect::{
-    connect_launch_app, connect_list_apps, connect_list_devices, connect_list_running,
-    connect_stop_app,
+    connect_launch_app, connect_list_apps, connect_list_cameras, connect_list_devices,
+    connect_list_running, connect_start_webcam, connect_stop_app, connect_stop_webcam,
+    connect_webcam_state,
 };
 use dbus_pool::DbusPool;
 use eventloops::{
@@ -209,6 +210,10 @@ pub fn run() {
             connect_launch_app,
             connect_stop_app,
             connect_list_running,
+            connect_list_cameras,
+            connect_start_webcam,
+            connect_stop_webcam,
+            connect_webcam_state,
             toggle_connect_menu
         ])
         .setup(move |app| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vasak-desktop",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "identifier": "ar.net.vasak.vasak-desktop",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/cards/PhoneControlCenterCard.vue
+++ b/src/components/cards/PhoneControlCenterCard.vue
@@ -3,15 +3,21 @@
 /** biome-ignore-all lint/correctness/noUnusedVariables: <Use in template> */
 import { useI18n } from '@vasakgroup/tauri-plugin-i18n';
 import { computed, onMounted, type Ref, ref } from 'vue';
-import type { ConnectDevice, ConnectRunningApp } from '@/interfaces/connect';
+import SwitchToggle from '@/components/forms/SwitchToggle.vue';
+import type { ConnectDevice, ConnectRunningApp, ConnectWebcamState } from '@/interfaces/connect';
 import {
+	connectWebcamState,
+	listConnectCameras,
 	listConnectDevices,
 	listConnectRunning,
+	startConnectWebcam,
 	stopConnectApp,
+	stopConnectWebcam,
 	toggleConnectMenu,
 } from '@/services/connect.service';
 import { useIcons } from '@/tools/composables/useReactiveIcon';
 import { useSharedEvent } from '@/tools/event.bus';
+import { camaraPorDefecto, encendidaEn, interruptorHabilitado } from '@/tools/webcam';
 
 /**
  * The phone's state, in the notification centre.
@@ -29,14 +35,123 @@ const { phoneIcon } = useIcons({ phoneIcon: 'smartphone' });
 
 const device = computed(() => devices.value[0]);
 
+const webcam: Ref<ConnectWebcamState | null> = ref(null);
+const cambiandoWebcam = ref(false);
+const errorWebcam = ref('');
+
+const refrescarWebcam = async () => {
+	webcam.value = await connectWebcamState();
+};
+
 const refresh = async () => {
 	devices.value = await listConnectDevices();
 	running.value = devices.value.length > 0 ? await listConnectRunning() : [];
+	// Sólo con un teléfono a la vista: sin ninguno la tarjeta no se dibuja, y
+	// preguntar por la webcam sería una llamada al bus para nadie.
+	if (devices.value.length > 0) await refrescarWebcam();
 };
 
 const close = async (app: ConnectRunningApp) => {
 	await stopConnectApp(app.serial, app.package);
 	running.value = await listConnectRunning();
+};
+
+// ── La cámara como webcam ───────────────────────────────────────────────────
+
+/**
+ * Si el módulo del kernel está cargado.
+ *
+ * Se pregunta por la ruta del dispositivo y no por `active`: el demonio la
+ * informa aunque no haya nada transmitiendo, justamente para poder decir esto
+ * *antes* de que alguien toque el interruptor.
+ */
+const hayLoopback = computed(() => (webcam.value?.device ?? '') !== '');
+
+/** Si la está usando este teléfono. */
+const webcamEncendida = computed(() => encendidaEn(webcam.value, device.value?.serial));
+
+/**
+ * Si la está usando otro teléfono.
+ *
+ * El dispositivo de vídeo admite un solo productor, así que un segundo teléfono
+ * no sumaría una cámara: arruinaría la primera. Mejor decirlo que dejar que el
+ * demonio conteste `WebcamBusy`.
+ */
+const webcamDeOtroTelefono = computed(
+	() => webcam.value?.active === true && !webcamEncendida.value
+);
+
+/**
+ * Cuándo se muestra la fila de la webcam.
+ *
+ * Con el teléfono listo, y **además** mientras esta cámara esté transmitiendo
+ * aunque deje de estarlo: si el teléfono se bloquea a mitad de una llamada, la
+ * fila se llevaría con ella el único interruptor que puede apagar la cámara.
+ */
+const mostrarWebcam = computed(() => device.value?.state === 'ready' || webcamEncendida.value);
+
+const interruptorHabilitadoAhora = computed(() =>
+	interruptorHabilitado({
+		estado: webcam.value,
+		serial: device.value?.serial,
+		telefonoListo: device.value?.state === 'ready',
+		enCurso: cambiandoWebcam.value,
+	})
+);
+
+/**
+ * La línea que acompaña al interruptor.
+ *
+ * Siempre dice algo: cuando está apagada, que hay que prenderla antes de abrir
+ * la videollamada. Eso no es un consejo de más — el módulo va con
+ * `exclusive_caps=1`, así que «VasakOS Phone» no aparece en Zoom, Firefox ni
+ * OBS hasta que el puente está transmitiendo, y esas aplicaciones enumeran las
+ * cámaras al arrancar. Prenderla después significa cerrar y reabrir la llamada.
+ */
+const detalleWebcam = computed(() => {
+	if (cambiandoWebcam.value) return t('views.connect.webcamWorking');
+	if (!hayLoopback.value) return t('views.connect.webcamNoModule');
+	if (webcamDeOtroTelefono.value) return t('views.connect.webcamBusy');
+	if (webcamEncendida.value) {
+		return t('views.connect.webcamActive').replace('{0}', webcam.value?.device ?? '');
+	}
+	return t('views.connect.webcamHint');
+});
+
+const alternarWebcam = async (encender: boolean) => {
+	const serial = device.value?.serial;
+	if (!serial || cambiandoWebcam.value) return;
+
+	cambiandoWebcam.value = true;
+	errorWebcam.value = '';
+
+	try {
+		if (!encender) {
+			await stopConnectWebcam();
+		} else {
+			// Las cámaras se piden acá y no al abrir la tarjeta: la primera
+			// consulta hace que scrcpy le pregunte al teléfono y tarda, y la
+			// mayoría de las veces que alguien abre el centro de notificaciones
+			// no viene a prender la webcam.
+			const camaras = await listConnectCameras(serial);
+			const elegida = camaraPorDefecto(camaras);
+			if (!elegida) {
+				errorWebcam.value = t('views.connect.webcamNoCameras');
+				return;
+			}
+			// Sin tamaño ni cuadros por segundo: que elija el teléfono. Los
+			// modos reales se eligen en Ajustes, donde hay lugar para mostrarlos.
+			await startConnectWebcam(serial, elegida.id);
+		}
+	} catch (reason) {
+		// El demonio explica bien sus fallos —falta el módulo, otra aplicación
+		// tiene la cámara, el teléfono se bloqueó— y perder ese texto es lo que
+		// vuelve incontestable un «no prendió».
+		errorWebcam.value = String(reason);
+	} finally {
+		cambiandoWebcam.value = false;
+		await refrescarWebcam();
+	}
 };
 
 onMounted(refresh);
@@ -45,6 +160,13 @@ useSharedEvent('connect-device-added', refresh);
 useSharedEvent('connect-device-changed', refresh);
 useSharedEvent('connect-device-removed', refresh);
 useSharedEvent('connect-app-closed', refresh);
+// La señal del demonio, y no un sondeo: el stream puede terminar sin que nadie
+// lo haya pedido —el teléfono se bloquea, otra de sus aplicaciones se queda con
+// la cámara— y un interruptor que siga diciendo «encendido» después de eso hace
+// creer que hay una cámara alimentando la llamada.
+useSharedEvent<ConnectWebcamState>('connect-webcam-changed', (estado) => {
+	webcam.value = estado;
+});
 </script>
 
 <template>
@@ -96,5 +218,27 @@ useSharedEvent('connect-app-closed', refresh);
         </button>
       </li>
     </ul>
+
+    <!-- La cámara del teléfono como webcam del sistema.
+         Va acá y no en Ajustes porque tiene que prenderse *antes* de abrir la
+         videollamada, y ésta es la única superficie que aparece exactamente
+         cuando hay un teléfono enchufado. La elección de cámara, resolución y
+         cuadros por segundo va en Ajustes, que es donde entran tres selectores. -->
+    <div
+      v-if="mostrarWebcam"
+      class="flex flex-col gap-1 border-t border-ui-border/60 pt-2"
+    >
+      <div class="flex items-center gap-2">
+        <span class="min-w-0 flex-1 text-sm text-tx-main">{{ t('views.connect.webcam') }}</span>
+        <SwitchToggle
+          :label="t('views.connect.webcam')"
+          :is-on="webcamEncendida"
+          :disabled="!interruptorHabilitadoAhora"
+          @toggle="alternarWebcam"
+        />
+      </div>
+      <p v-if="errorWebcam" class="text-status-error text-xs">{{ errorWebcam }}</p>
+      <p v-else class="text-tx-muted text-xs">{{ detalleWebcam }}</p>
+    </div>
   </div>
 </template>

--- a/src/components/cards/PhoneControlCenterCard.vue
+++ b/src/components/cards/PhoneControlCenterCard.vue
@@ -17,7 +17,12 @@ import {
 } from '@/services/connect.service';
 import { useIcons } from '@/tools/composables/useReactiveIcon';
 import { useSharedEvent } from '@/tools/event.bus';
-import { camaraPorDefecto, encendidaEn, interruptorHabilitado } from '@/tools/webcam';
+import {
+	camaraPorDefecto,
+	diagnosticoWebcam,
+	encendidaEn,
+	interruptorHabilitado,
+} from '@/tools/webcam';
 
 /**
  * The phone's state, in the notification centre.
@@ -38,9 +43,25 @@ const device = computed(() => devices.value[0]);
 const webcam: Ref<ConnectWebcamState | null> = ref(null);
 const cambiandoWebcam = ref(false);
 const errorWebcam = ref('');
+const errorEstadoWebcam = ref('');
 
+/**
+ * Relee lo que dice el demonio sobre la cámara.
+ *
+ * **Un fallo de lectura no se convierte en un estado.** Se conserva el último
+ * conocido en lugar de dar la cámara por apagada: si estaba encendida, el
+ * interruptor tiene que seguir pudiendo apagarla. Y sobre todo no se finge un
+ * estado vacío, porque un dispositivo vacío ya significa algo —falta el módulo
+ * v4l2loopback, se arregla con un `modprobe` o reiniciando— y decir eso por un
+ * error de bus manda a alguien a reiniciar al vacío.
+ */
 const refrescarWebcam = async () => {
-	webcam.value = await connectWebcamState();
+	try {
+		webcam.value = await connectWebcamState();
+		errorEstadoWebcam.value = '';
+	} catch (reason) {
+		errorEstadoWebcam.value = String(reason);
+	}
 };
 
 const refresh = async () => {
@@ -58,28 +79,8 @@ const close = async (app: ConnectRunningApp) => {
 
 // ── La cámara como webcam ───────────────────────────────────────────────────
 
-/**
- * Si el módulo del kernel está cargado.
- *
- * Se pregunta por la ruta del dispositivo y no por `active`: el demonio la
- * informa aunque no haya nada transmitiendo, justamente para poder decir esto
- * *antes* de que alguien toque el interruptor.
- */
-const hayLoopback = computed(() => (webcam.value?.device ?? '') !== '');
-
 /** Si la está usando este teléfono. */
 const webcamEncendida = computed(() => encendidaEn(webcam.value, device.value?.serial));
-
-/**
- * Si la está usando otro teléfono.
- *
- * El dispositivo de vídeo admite un solo productor, así que un segundo teléfono
- * no sumaría una cámara: arruinaría la primera. Mejor decirlo que dejar que el
- * demonio conteste `WebcamBusy`.
- */
-const webcamDeOtroTelefono = computed(
-	() => webcam.value?.active === true && !webcamEncendida.value
-);
 
 /**
  * Cuándo se muestra la fila de la webcam.
@@ -110,12 +111,21 @@ const interruptorHabilitadoAhora = computed(() =>
  */
 const detalleWebcam = computed(() => {
 	if (cambiandoWebcam.value) return t('views.connect.webcamWorking');
-	if (!hayLoopback.value) return t('views.connect.webcamNoModule');
-	if (webcamDeOtroTelefono.value) return t('views.connect.webcamBusy');
-	if (webcamEncendida.value) {
-		return t('views.connect.webcamActive').replace('{0}', webcam.value?.device ?? '');
+
+	switch (diagnosticoWebcam(webcam.value, device.value?.serial)) {
+		// Callarse hasta saber: sin estado leído no se puede afirmar nada, y el
+		// que estaría más a mano —«falta el módulo»— manda a reiniciar el equipo.
+		case 'desconocido':
+			return '';
+		case 'sin-modulo':
+			return t('views.connect.webcamNoModule');
+		case 'ocupada':
+			return t('views.connect.webcamBusy');
+		case 'encendida':
+			return t('views.connect.webcamActive').replace('{0}', webcam.value?.device ?? '');
+		default:
+			return t('views.connect.webcamHint');
 	}
-	return t('views.connect.webcamHint');
 });
 
 const alternarWebcam = async (encender: boolean) => {
@@ -127,6 +137,12 @@ const alternarWebcam = async (encender: boolean) => {
 
 	try {
 		if (!encender) {
+			// `StopWebcam` no lleva serial: corta lo que esté transmitiendo,
+			// porque el dispositivo de vídeo admite un solo productor. Así que se
+			// relee antes de cortar — si entre que se dibujó el interruptor y el
+			// clic la cámara pasó a ser de otro teléfono, apagaríamos la de él.
+			await refrescarWebcam();
+			if (!encendidaEn(webcam.value, serial)) return;
 			await stopConnectWebcam();
 		} else {
 			// Las cámaras se piden acá y no al abrir la tarjeta: la primera
@@ -237,8 +253,13 @@ useSharedEvent<ConnectWebcamState>('connect-webcam-changed', (estado) => {
           @toggle="alternarWebcam"
         />
       </div>
-      <p v-if="errorWebcam" class="text-status-error text-xs">{{ errorWebcam }}</p>
-      <p v-else class="text-tx-muted text-xs">{{ detalleWebcam }}</p>
+      <!-- El error de una acción primero, y el de la lectura del estado
+           después: los dos son texto del demonio y ninguno se puede reemplazar
+           por el consejo del módulo, que sería un diagnóstico inventado. -->
+      <p v-if="errorWebcam || errorEstadoWebcam" class="text-status-error text-xs">
+        {{ errorWebcam || errorEstadoWebcam }}
+      </p>
+      <p v-else-if="detalleWebcam" class="text-tx-muted text-xs">{{ detalleWebcam }}</p>
     </div>
   </div>
 </template>

--- a/src/interfaces/connect.ts
+++ b/src/interfaces/connect.ts
@@ -40,3 +40,41 @@ export interface ConnectRunningApp {
 	label: string;
 	pid: number;
 }
+
+/**
+ * Which way a camera points.
+ *
+ * The only thing that tells a person which camera they are picking: an id of
+ * `0` or `2` means nothing to anybody. `external` also covers a word the
+ * daemon did not recognise, so the camera is still listed — just without a
+ * promise about where it points.
+ */
+export type ConnectCameraFacing = 'back' | 'front' | 'external';
+
+export interface ConnectCamera {
+	/** scrcpy's camera id. Opaque, and only unique within one phone. */
+	id: string;
+	facing: ConnectCameraFacing;
+	/** Capture sizes the sensor accepts, largest first, as `1280x720`. */
+	sizes: string[];
+	fps: number[];
+}
+
+/** What the webcam bridge is doing. */
+export interface ConnectWebcamState {
+	active: boolean;
+	/**
+	 * The device other applications open, e.g. `/dev/video42`.
+	 *
+	 * Empty means the v4l2loopback module is not loaded — reported outside
+	 * `active` because it is the one failure a person can fix, and they have to
+	 * see it before pressing anything.
+	 */
+	device: string;
+	/** Which phone is feeding it. Empty unless `active`. */
+	serial: string;
+	/** Empty unless `active`. */
+	camera_id: string;
+	/** Empty unless `active`. */
+	size: string;
+}

--- a/src/services/connect.service.ts
+++ b/src/services/connect.service.ts
@@ -62,6 +62,12 @@ export const startConnectWebcam = (
 /** Stops the stream. `false` means there was nothing streaming. */
 export const stopConnectWebcam = (): Promise<boolean> => invoke<boolean>('connect_stop_webcam');
 
-/** What the bridge is doing, and whether it could run at all. */
+/**
+ * What the bridge is doing, and whether it could run at all.
+ *
+ * Rejects rather than answering with an empty state: an empty `device` already
+ * means "the v4l2loopback module is not loaded", and returning that for a call
+ * that merely failed would send somebody to reboot over a bus timeout.
+ */
 export const connectWebcamState = (): Promise<ConnectWebcamState> =>
 	invoke<ConnectWebcamState>('connect_webcam_state');

--- a/src/services/connect.service.ts
+++ b/src/services/connect.service.ts
@@ -1,5 +1,11 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { ConnectApp, ConnectDevice, ConnectRunningApp } from '@/interfaces/connect';
+import type {
+	ConnectApp,
+	ConnectCamera,
+	ConnectDevice,
+	ConnectRunningApp,
+	ConnectWebcamState,
+} from '@/interfaces/connect';
 
 /**
  * The phones connected right now.
@@ -31,3 +37,31 @@ export const listConnectRunning = (): Promise<ConnectRunningApp[]> =>
 	invoke<ConnectRunningApp[]>('connect_list_running');
 
 export const toggleConnectMenu = (): Promise<void> => invoke<void>('toggle_connect_menu');
+
+/** The cameras a phone has. Cached by the daemon; `refresh` re-asks the phone. */
+export const listConnectCameras = (serial: string, refresh = false): Promise<ConnectCamera[]> =>
+	invoke<ConnectCamera[]>('connect_list_cameras', { serial, refresh });
+
+/**
+ * Starts writing a phone camera into the loopback device.
+ *
+ * Resolves to the device path other applications open. An empty `size` and a
+ * zero `fps` let the phone choose, which is what the control centre does — the
+ * modes belong in the settings screen, where there is room for three selects.
+ *
+ * Rejects, unlike the listing calls: this runs because somebody pressed a
+ * switch, and a switch that silently returns to off explains nothing.
+ */
+export const startConnectWebcam = (
+	serial: string,
+	cameraId: string,
+	size = '',
+	fps = 0
+): Promise<string> => invoke<string>('connect_start_webcam', { serial, cameraId, size, fps });
+
+/** Stops the stream. `false` means there was nothing streaming. */
+export const stopConnectWebcam = (): Promise<boolean> => invoke<boolean>('connect_stop_webcam');
+
+/** What the bridge is doing, and whether it could run at all. */
+export const connectWebcamState = (): Promise<ConnectWebcamState> =>
+	invoke<ConnectWebcamState>('connect_webcam_state');

--- a/src/tools/webcam.test.ts
+++ b/src/tools/webcam.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { ConnectCamera, ConnectCameraFacing, ConnectWebcamState } from '@/interfaces/connect';
-import { camaraPorDefecto, encendidaEn, interruptorHabilitado } from './webcam';
+import { camaraPorDefecto, diagnosticoWebcam, encendidaEn, interruptorHabilitado } from './webcam';
 
 const camara = (id: string, facing: ConnectCameraFacing): ConnectCamera => ({
 	id,
@@ -168,5 +168,31 @@ describe('cuándo se puede tocar el interruptor', () => {
 				enCurso: false,
 			})
 		).toBe(false);
+	});
+});
+
+describe('el diagnóstico de la cámara', () => {
+	test('sin estado leído todavía, no se sabe nada', () => {
+		// La regla que importa: un estado ausente **no** es un estado vacío. Sin
+		// esto, la tarjeta anunciaba que falta el módulo del kernel mientras la
+		// respuesta venía en camino, o cuando la consulta al demonio falló, y el
+		// arreglo que ofrecía era reiniciar el equipo.
+		expect(diagnosticoWebcam(null, 'ABC123')).toBe('desconocido');
+	});
+
+	test('sin dispositivo, falta el módulo del kernel', () => {
+		expect(diagnosticoWebcam(apagada(''), 'ABC123')).toBe('sin-modulo');
+	});
+
+	test('lista cuando hay módulo y nada transmitiendo', () => {
+		expect(diagnosticoWebcam(apagada(), 'ABC123')).toBe('lista');
+	});
+
+	test('encendida cuando la alimenta este teléfono', () => {
+		expect(diagnosticoWebcam(transmitiendo('ABC123'), 'ABC123')).toBe('encendida');
+	});
+
+	test('ocupada cuando la alimenta otro', () => {
+		expect(diagnosticoWebcam(transmitiendo('XYZ789'), 'ABC123')).toBe('ocupada');
 	});
 });

--- a/src/tools/webcam.test.ts
+++ b/src/tools/webcam.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from 'bun:test';
+import type { ConnectCamera, ConnectCameraFacing, ConnectWebcamState } from '@/interfaces/connect';
+import { camaraPorDefecto, encendidaEn, interruptorHabilitado } from './webcam';
+
+const camara = (id: string, facing: ConnectCameraFacing): ConnectCamera => ({
+	id,
+	facing,
+	sizes: ['1280x720'],
+	fps: [30],
+});
+
+const apagada = (device = '/dev/video42'): ConnectWebcamState => ({
+	active: false,
+	device,
+	serial: '',
+	camera_id: '',
+	size: '',
+});
+
+const transmitiendo = (serial: string): ConnectWebcamState => ({
+	active: true,
+	device: '/dev/video42',
+	serial,
+	camera_id: '0',
+	size: '1280x720',
+});
+
+describe('la cámara por defecto', () => {
+	test('es la trasera cuando el teléfono tiene las dos', () => {
+		// Es la que apunta a la persona con el teléfono apoyado contra el
+		// monitor, y el mejor sensor de los dos.
+		expect(camaraPorDefecto([camara('1', 'front'), camara('0', 'back')])?.id).toBe('0');
+	});
+
+	test('no depende del orden en que las liste el teléfono', () => {
+		expect(camaraPorDefecto([camara('0', 'back'), camara('1', 'front')])?.id).toBe('0');
+	});
+
+	test('sin trasera se usa la primera que haya', () => {
+		// Negarse dejaría sin webcam a un teléfono que puede transmitir.
+		expect(camaraPorDefecto([camara('9', 'external'), camara('1', 'front')])?.id).toBe('9');
+	});
+
+	test('sin cámaras no hay ninguna', () => {
+		// El interruptor tiene que quedar deshabilitado, no llamar al demonio
+		// con un id vacío: `StartWebcam` con una cámara que no existe abre el
+		// stream y lo mata medio segundo después.
+		expect(camaraPorDefecto([])).toBeUndefined();
+	});
+});
+
+describe('de quién es la cámara encendida', () => {
+	test('del teléfono cuyo serial coincide', () => {
+		expect(encendidaEn(transmitiendo('ABC123'), 'ABC123')).toBe(true);
+	});
+
+	test('con dos teléfonos, el otro no la muestra como encendida', () => {
+		// El dispositivo de vídeo admite un productor. La tarjeta del teléfono
+		// que no está transmitiendo no puede decir que sí.
+		expect(encendidaEn(transmitiendo('ABC123'), 'XYZ789')).toBe(false);
+	});
+
+	test('sin nada transmitiendo, no', () => {
+		expect(encendidaEn(apagada(), 'ABC123')).toBe(false);
+	});
+
+	test('sin estado todavía leído, no', () => {
+		expect(encendidaEn(null, 'ABC123')).toBe(false);
+	});
+
+	test('sin teléfono, no', () => {
+		// Si no hay serial no hay a quién atribuirla, y `estado.serial === undefined`
+		// sería `true` para un estado con serial vacío.
+		expect(encendidaEn(apagada(), undefined)).toBe(false);
+	});
+});
+
+describe('cuándo se puede tocar el interruptor', () => {
+	test('prender, con el teléfono listo y el módulo cargado', () => {
+		expect(
+			interruptorHabilitado({
+				estado: apagada(),
+				serial: 'ABC123',
+				telefonoListo: true,
+				enCurso: false,
+			})
+		).toBe(true);
+	});
+
+	test('apagar se puede aunque el teléfono ya no esté listo', () => {
+		// El caso importante: el teléfono se bloquea o el cable se mueve
+		// mientras la cámara transmite. Si esto devolviera `false`, quedaría una
+		// cámara encendida y el interruptor gris.
+		expect(
+			interruptorHabilitado({
+				estado: transmitiendo('ABC123'),
+				serial: 'ABC123',
+				telefonoListo: false,
+				enCurso: false,
+			})
+		).toBe(true);
+	});
+
+	test('no se puede prender sin el módulo del kernel', () => {
+		// Sin v4l2loopback no hay dónde escribir la cámara. La ruta vacía es
+		// cómo lo informa el demonio, y llega incluso con `active` en falso
+		// justamente para poder decirlo antes de que alguien apriete.
+		expect(
+			interruptorHabilitado({
+				estado: apagada(''),
+				serial: 'ABC123',
+				telefonoListo: true,
+				enCurso: false,
+			})
+		).toBe(false);
+	});
+
+	test('no se puede prender si la está usando otro teléfono', () => {
+		// El demonio contestaría `WebcamBusy`; mejor no ofrecerlo.
+		expect(
+			interruptorHabilitado({
+				estado: transmitiendo('XYZ789'),
+				serial: 'ABC123',
+				telefonoListo: true,
+				enCurso: false,
+			})
+		).toBe(false);
+	});
+
+	test('no se puede prender con el teléfono a medio autorizar', () => {
+		expect(
+			interruptorHabilitado({
+				estado: apagada(),
+				serial: 'ABC123',
+				telefonoListo: false,
+				enCurso: false,
+			})
+		).toBe(false);
+	});
+
+	test('una operación en curso bloquea las dos direcciones', () => {
+		// Sin esto, dos clics seguidos mandan dos llamadas y la segunda decide
+		// el estado final, que puede ser el contrario del último clic.
+		expect(
+			interruptorHabilitado({
+				estado: transmitiendo('ABC123'),
+				serial: 'ABC123',
+				telefonoListo: true,
+				enCurso: true,
+			})
+		).toBe(false);
+		expect(
+			interruptorHabilitado({
+				estado: apagada(),
+				serial: 'ABC123',
+				telefonoListo: true,
+				enCurso: true,
+			})
+		).toBe(false);
+	});
+
+	test('sin estado leído todavía no se ofrece nada', () => {
+		expect(
+			interruptorHabilitado({
+				estado: null,
+				serial: 'ABC123',
+				telefonoListo: true,
+				enCurso: false,
+			})
+		).toBe(false);
+	});
+});

--- a/src/tools/webcam.ts
+++ b/src/tools/webcam.ts
@@ -1,0 +1,79 @@
+/**
+ * Las reglas del interruptor de la webcam del teléfono.
+ *
+ * El interruptor del centro de control no pregunta nada: se prende y transmite.
+ * La elección fina —cámara, resolución, cuadros por segundo— va en Ajustes,
+ * donde hay lugar para tres selectores; acá hace falta un valor por defecto que
+ * sea el correcto casi siempre, porque el camino de uso es «enchufo el
+ * teléfono, prendo, abro la videollamada».
+ *
+ * Vive aparte del componente porque decide cuándo se puede **apagar** una
+ * cámara que está transmitiendo, y equivocarse ahí deja una cámara encendida
+ * sin forma de cortarla. Eso no se prueba mirando una tarjeta.
+ */
+
+import type { ConnectCamera, ConnectWebcamState } from '@/interfaces/connect';
+
+/**
+ * La cámara que conviene usar de las que tiene el teléfono.
+ *
+ * **La trasera primero.** Un teléfono usado como webcam se apoya contra el
+ * monitor con la pantalla hacia afuera, así que la que apunta a la persona es
+ * la de atrás — y encima es el mejor sensor de los dos. La frontal sirve cuando
+ * el teléfono se sostiene en la mano, que no es este caso.
+ *
+ * Si no hay ninguna trasera se usa la primera que haya, en lugar de no ofrecer
+ * nada: un teléfono con una sola cámara clasificada como `external` igual puede
+ * transmitir, y negarse sería inventar un requisito.
+ */
+export function camaraPorDefecto(camaras: readonly ConnectCamera[]): ConnectCamera | undefined {
+	return camaras.find((camara) => camara.facing === 'back') ?? camaras[0];
+}
+
+/**
+ * Si la webcam la está alimentando **este** teléfono.
+ *
+ * El serial importa: con dos teléfonos enchufados, el que transmite es uno solo
+ * —el dispositivo de vídeo admite un productor— y la tarjeta del otro no puede
+ * mostrar su interruptor encendido.
+ */
+export function encendidaEn(estado: ConnectWebcamState | null, serial?: string): boolean {
+	return estado?.active === true && !!serial && estado.serial === serial;
+}
+
+/** Lo que hace falta saber para decidir si el interruptor se puede tocar. */
+export interface SituacionWebcam {
+	estado: ConnectWebcamState | null;
+	/** El teléfono de esta tarjeta. */
+	serial?: string;
+	/** Si el teléfono terminó de autorizarse y está listo para trabajar. */
+	telefonoListo: boolean;
+	/** Si hay un encendido o apagado a mitad de camino. */
+	enCurso: boolean;
+}
+
+/**
+ * Si el interruptor se puede tocar.
+ *
+ * **Apagar puede casi siempre.** Si esta cámara está transmitiendo, el
+ * interruptor responde aunque el teléfono haya dejado de estar «listo»: dejar
+ * una cámara encendida sin forma de cortarla es lo peor que puede hacer esta
+ * tarjeta, y es la clase de estado en el que se cae solo —el teléfono se
+ * bloquea, el cable se mueve— justo cuando alguien quiere apagarla.
+ *
+ * Prender pide las tres condiciones: teléfono listo, módulo del kernel cargado
+ * —sin él no hay dónde escribir— y que no haya otra cámara transmitiendo, que
+ * el demonio rechazaría con `WebcamBusy`.
+ *
+ * Lo único que bloquea las dos direcciones es una operación en curso.
+ */
+export function interruptorHabilitado(situacion: SituacionWebcam): boolean {
+	if (situacion.enCurso) return false;
+	if (encendidaEn(situacion.estado, situacion.serial)) return true;
+
+	return (
+		situacion.telefonoListo &&
+		(situacion.estado?.device ?? '') !== '' &&
+		situacion.estado?.active !== true
+	);
+}

--- a/src/tools/webcam.ts
+++ b/src/tools/webcam.ts
@@ -41,6 +41,35 @@ export function encendidaEn(estado: ConnectWebcamState | null, serial?: string):
 	return estado?.active === true && !!serial && estado.serial === serial;
 }
 
+/**
+ * En qué situación está la cámara, para poder decirlo con una sola frase.
+ *
+ * `desconocido` existe y no es un detalle: mientras la respuesta del demonio
+ * viene en camino —o si la lectura falló— **no se sabe nada**, y hay que
+ * callarse. Sin este valor, un estado ausente se lee como uno vacío, un
+ * dispositivo vacío significa «falta el módulo v4l2loopback», y la tarjeta
+ * termina mandando a reiniciar por una consulta que simplemente no volvió.
+ */
+export type DiagnosticoWebcam = 'desconocido' | 'sin-modulo' | 'ocupada' | 'encendida' | 'lista';
+
+/**
+ * Qué le pasa a la cámara desde el punto de vista de este teléfono.
+ *
+ * El orden importa: sin módulo no hay nada más que decir —ni siquiera se puede
+ * estar transmitiendo—, y «encendida» se decide antes que «ocupada» porque
+ * ocupada significa «la tiene otro».
+ */
+export function diagnosticoWebcam(
+	estado: ConnectWebcamState | null,
+	serial?: string
+): DiagnosticoWebcam {
+	if (estado === null) return 'desconocido';
+	if (estado.device === '') return 'sin-modulo';
+	if (encendidaEn(estado, serial)) return 'encendida';
+	if (estado.active) return 'ocupada';
+	return 'lista';
+}
+
 /** Lo que hace falta saber para decidir si el interruptor se puede tocar. */
 export interface SituacionWebcam {
 	estado: ConnectWebcamState | null;


### PR DESCRIPTION
## Por qué

El demonio de vasak-connect sabe usar la cámara del teléfono como webcam desde la 0.2.0. `StartWebcam`, `StopWebcam`, `ListCameras` y `WebcamState` estaban publicados en el bus y **ninguno de los cuatro tenía un solo llamador**: la función se podía usar sólo con `busctl`. Es la razón por la que seguía figurando como «sin probar de punta a punta».

## Qué hace

Un interruptor en la tarjeta del teléfono, en el centro de notificaciones.

**Por qué ahí y no en Ajustes.** El módulo se carga con `exclusive_caps=1`, así que «VasakOS Phone» no aparece en Zoom, Firefox ni OBS hasta que el puente está transmitiendo — y esas aplicaciones enumeran las cámaras al arrancar. Hay que prenderla *antes* de abrir la llamada. Esta tarjeta es la única superficie que aparece exactamente cuando hay un teléfono enchufado, y la línea de ayuda lo dice mientras está apagada. Con el interruptor enterrado en Ajustes, el camino real sería: abrir la llamada, no encontrar la cámara, ir a Ajustes, prender, cerrar y reabrir la llamada.

**No pregunta nada.** Usa la cámara trasera si el teléfono la tiene —es la que apunta a la persona con el teléfono apoyado contra el monitor, y el mejor sensor de los dos— y deja que el teléfono elija resolución y cuadros por segundo. Los modos reales del sensor se eligen en Ajustes, donde entran tres selectores; eso es el siguiente paso, no éste.

## Lo que explica en lugar de fallar

| situación | qué se ve |
|---|---|
| falta el módulo v4l2loopback | «Si actualizaste el kernel, reiniciá», con el interruptor deshabilitado |
| la usa otro teléfono | «La está usando otro teléfono» — el dispositivo admite un productor, un segundo no sumaría una cámara: arruinaría la primera |
| error del demonio | el texto tal como lo escribió, en lugar de un interruptor que vuelve solo a apagado |

Lo del módulo se sabe por la ruta vacía que informa `WebcamState`, que llega **incluso con la cámara apagada** justamente para poder decirlo antes de que alguien apriete.

## Una señal que se estaba descartando

`WebcamChanged` no se reenviaba en `watch_signals`. El stream puede terminar sin que nadie lo pida —el teléfono se bloquea, otra de sus aplicaciones se queda con la cámara— y un interruptor que siga diciendo «encendido» después de eso hace creer que hay una cámara alimentando la llamada.

## Tests

12 nuevos en `src/tools/webcam.ts`, 61 en total; `vue-tsc`, biome y clippy en cero.

Las reglas del interruptor están en una función pura y no en el componente porque una de ellas es que **apagar se puede casi siempre**: si el teléfono deja de estar listo mientras la cámara transmite, el interruptor sigue respondiendo *y la fila sigue estando*. Escribí las dos mal en el primer intento —la fila desaparecía con `device.state === 'ready'`— y el test es lo que lo marcó.

## Lo que no está probado

No hay teléfono conectado en esta máquina, así que el camino en vivo no lo vi. Lo verificado es el contrato contra el demonio —firmas, tipos y que `CameraFacing` viaja como cadena por `#[zvariant(signature = "s")]`—, los tipos, el lint y la lógica del interruptor.

Con esto la webcam se puede probar de punta a punta con tu teléfono, que es lo que hasta ahora no había forma de hacer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Use a connected phone’s camera as a webcam directly from the Phone Control Center.
  - Select and activate an available camera, with support for camera resolution and frame-rate options.
  - View live webcam status, including active device details and connection updates.
- **Bug Fixes**
  - Added clear feedback for unavailable webcam support, busy cameras, missing system components, and phones without cameras.
- **Documentation**
  - Added English and Spanish translations for webcam controls and status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->