### PR TITLE
Versión 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vasak-desktop",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "engines": {
     "bun": ">=1.2.21"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5856,7 +5856,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vasak-desktop"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vasak-desktop"
-version = "1.4.0"
+version = "1.4.1"
 description = "A Vasak Application (template)"
 authors = ["Vasak Group", "Joaquin (Pato) Decima"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vasak-desktop",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "ar.net.vasak.vasak-desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Para que la recompilación tome `PresentApp` (#59).

El paquete publicado es `1.4.0-1`, la misma versión que tiene el repositorio, así que `build-all.sh` lo declara «up to date» y no lo vuelve a compilar.

Sube los tres archivos con la versión más el `Cargo.lock`. El `pkgver` del PKGBUILD acompaña en su repositorio.