### PR TITLE
fix: una línea en blanco de más al declarar las fuentes

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -18,7 +18,6 @@
   --vsk-font-title: sans-serif;
   --vsk-font-terminal: monospace;
 
-
   /* Colores de Marca */
   --primary: #dd7878;
   --secondary: #8839ef;


### PR DESCRIPTION
## Qué

Una línea en blanco de más, entre la declaración de las fuentes y los colores de marca. `biome format` la marca.

## Cómo se me pasó

La dejé al insertar los tokens en el PR de las tres fuentes. Comparé la cuenta de hallazgos de biome antes y después del cambio, y en los archivos que **ya tenían** un hallazgo de formato la cuenta no se movió — así que la comprobación no distinguía «no rompí nada» de «rompí algo y tapé el conteo». Había que comparar el contenido, no el número.

## Prueba

`biome check` sobre la hoja: limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)