### PR TITLE
fix: las credenciales de una URL ya no llegan al registro de CSP

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,72 +5,23 @@ import { createPinia } from 'pinia';
 import { createApp } from 'vue';
 import App from '@/App.vue';
 import { router } from '@/routes/index';
+import { sanearUrl } from '@/tools/csp';
 import '@/assets/main.css';
 import { captureFailures } from '@vasakgroup/plugin-vsk-journal';
-
-/**
- * Los valores que la especificación de CSP informa en lugar de una URL.
- *
- * Van tal cual: no son rutas y recortarlos los volvería ilegibles.
- */
-const MARCADORES_CSP = new Set([
-	'inline',
-	'eval',
-	'wasm-eval',
-	'data',
-	'blob',
-	'filesystem',
-	'self',
-	'unsafe-eval',
-	'unsafe-inline',
-]);
-
-/**
- * Saca de una URL lo que no debería quedar en un registro.
- *
- * Se conserva el esquema y la autoridad usando `href`, y no `origin + pathname`:
- * para esquemas propios como `asset:` o `ipc:` el `origin` es la cadena «null»,
- * así que esa forma escribía `null/ruta` y perdía justamente lo que permite
- * entender qué se bloqueó.
- *
- * El caso que faltaba cubrir es el del `catch`: una ruta relativa o
- * protocol-relative hace que `new URL` falle, y devolverla tal cual dejaba la
- * query y el fragmento en el registro — o sea, exactamente lo que esta función
- * viene a evitar. Ahora sólo pasan sin tocar los marcadores de la
- * especificación; cualquier otra cosa se corta antes de `?` o `#`.
- */
-const sanearUrl = (valor: string | null | undefined): string => {
-	if (!valor) {
-		return '';
-	}
-	try {
-		const url = new URL(valor);
-		if (url.protocol === 'data:') {
-			return 'data:(recortado)';
-		}
-		// Credenciales, query y fragmento: ahí es donde viajan los tokens.
-		url.username = '';
-		url.password = '';
-		url.search = '';
-		url.hash = '';
-		return url.href;
-	} catch {
-		if (MARCADORES_CSP.has(valor)) {
-			return valor;
-		}
-		return valor.split(/[?#]/)[0];
-	}
-};
 
 // Una violación de CSP no se ve: el recurso no carga y la interfaz queda a
 // medias sin decir nada. Se sanean **las dos** URLs, porque `sourceFile` también
 // puede llevar query con datos sensibles.
 document.addEventListener('securitypolicyviolation', (evento) => {
-	// El respaldo se decide antes de sanear: `sanearUrl` nunca devuelve vacío
-	// para una entrada con contenido, así que un `|| 'documento'` después de
-	// llamarla era código muerto.
-	const recurso = evento.blockedURI ? sanearUrl(evento.blockedURI) : '(en línea)';
-	const origen = evento.sourceFile ? sanearUrl(evento.sourceFile) : 'documento';
+	// El respaldo va **después** de sanear, no antes.
+	//
+	// Mirando el valor crudo, una entrada como `?token=X` es verdadera y
+	// pasa el respaldo de largo — pero lo que queda de ella al sanearla es
+	// nada, así que el registro salía con el campo en blanco. Sanear
+	// primero y decidir después es lo que hace que un aviso incompleto no
+	// exista.
+	const recurso = sanearUrl(evento.blockedURI) || '(en línea)';
+	const origen = sanearUrl(evento.sourceFile) || 'documento';
 	console.error(
 		`[CSP] bloqueado ${recurso} por la directiva ` +
 			`«${evento.violatedDirective}» en ${origen}:${evento.lineNumber}`

--- a/src/tools/csp.ts
+++ b/src/tools/csp.ts
@@ -1,0 +1,111 @@
+/**
+ * Sanear lo que se escribe al registrar una violación de la política de
+ * contenido.
+ *
+ * Una violación de CSP no se ve: el recurso no carga y la interfaz queda a
+ * medias sin decir nada. Por eso se registran. Pero lo que se registra es una
+ * URL que eligió otro, y las URL llevan credenciales: `//usuario:token@sitio`,
+ * `?access_token=…`. Escribirlas al diario las deja ahí para siempre, legibles
+ * por cualquiera que lo lea.
+ *
+ * Este módulo existe aparte de `main.ts` para poder probarlo: importar `main.ts`
+ * arranca la aplicación.
+ */
+
+/**
+ * Lo que la especificación de CSP puede poner en lugar de una URL.
+ *
+ * No son direcciones, así que no se sanean: se dejan tal cual porque son la
+ * información útil del aviso.
+ */
+export const MARCADORES_CSP = new Set([
+	'inline',
+	'eval',
+	'wasm-eval',
+	'data',
+	'blob',
+	'filesystem',
+	'self',
+	'unsafe-eval',
+	'unsafe-inline',
+]);
+
+/**
+ * Los esquemas cuyo contenido después de `:` es una ruta y no una carga útil.
+ *
+ * Para el resto se registra sólo el esquema. La razón es que `new URL` acepta
+ * cualquier cosa con dos puntos como un esquema opaco: `user:token@sitio/x`
+ * parsea bien, con `username` **vacío** y el token entero en `href`. O sea que
+ * limpiar `username` y `password` no alcanza — para un esquema opaco esos
+ * campos ni existen, y el token viaja en lo que la URL llama «ruta».
+ *
+ * Recortar no pierde lo que sirve: para depurar un bloqueo de CSP lo que
+ * importa es qué esquema se bloqueó, no qué había adentro.
+ */
+const ESQUEMAS_CON_RUTA = new Set([
+	'http:',
+	'https:',
+	'ws:',
+	'wss:',
+	'ftp:',
+	'file:',
+	'blob:',
+	// Los que usa Tauri para servir la aplicación y hablar con el backend.
+	'tauri:',
+	'asset:',
+	'ipc:',
+]);
+
+/** Un esquema inventado para poder parsear una URL sin esquema propio. */
+const ESQUEMA_PRESTADO = 'https:';
+
+function sinCredenciales(url: URL): URL {
+	url.username = '';
+	url.password = '';
+	url.search = '';
+	url.hash = '';
+	return url;
+}
+
+/**
+ * Saca de una URL lo que no debería quedar en un registro.
+ *
+ * Devuelve cadena vacía para lo que no tiene nada que registrar —una entrada
+ * vacía, o una que era sólo query o fragmento—. Quien la use tiene que aplicar
+ * su texto de reserva **después** de llamar acá y no antes: una entrada como
+ * `?token=X` no es vacía, pero lo que queda de ella sí.
+ */
+export function sanearUrl(valor: string | null | undefined): string {
+	if (!valor) {
+		return '';
+	}
+
+	if (MARCADORES_CSP.has(valor)) {
+		return valor;
+	}
+
+	// Relativas al protocolo: `//usuario:token@sitio/x`. `new URL` sin base las
+	// rechaza, y la versión anterior caía a cortar por `?` y `#`, que deja
+	// `usuario:token@` intacto. Se parsean con un esquema prestado y se
+	// devuelven en la misma forma en que llegaron.
+	if (valor.startsWith('//')) {
+		try {
+			const url = sinCredenciales(new URL(`${ESQUEMA_PRESTADO}${valor}`));
+			return `//${url.host}${url.pathname}`;
+		} catch {
+			// Ni con esquema prestado: no es una URL. Cae al corte de abajo.
+		}
+	}
+
+	try {
+		const url = new URL(valor);
+		if (!ESQUEMAS_CON_RUTA.has(url.protocol)) {
+			return `${url.protocol}(recortado)`;
+		}
+		return sinCredenciales(url).href;
+	} catch {
+		// Una ruta relativa. No puede llevar credenciales —eso necesita una
+		// autoridad— así que alcanza con quitarle la query y el fragmento.
+		return valor.split(/[?#]/)[0];
+	}
+}

--- a/src/tools/csp.ts
+++ b/src/tools/csp.ts
@@ -31,16 +31,18 @@ export const MARCADORES_CSP = new Set([
 ]);
 
 /**
- * Los esquemas cuyo contenido después de `:` es una ruta y no una carga útil.
+ * Los esquemas cuyo contenido después de `:` **puede** ser una ruta.
  *
- * Para el resto se registra sólo el esquema. La razón es que `new URL` acepta
- * cualquier cosa con dos puntos como un esquema opaco: `user:token@sitio/x`
- * parsea bien, con `username` **vacío** y el token entero en `href`. O sea que
- * limpiar `username` y `password` no alcanza — para un esquema opaco esos
- * campos ni existen, y el token viaja en lo que la URL llama «ruta».
+ * «Puede» y no «es»: que el esquema esté en esta lista no alcanza, porque el
+ * mismo esquema admite las dos formas. `asset://sitio/x` es jerárquico y
+ * `asset:user:token@sitio` es opaco, y el segundo mete el token en lo que la
+ * URL llama «ruta», donde limpiar `username` y `password` no hace nada — para
+ * un esquema opaco esos campos ni existen. Por eso además se comprueba que la
+ * dirección tenga autoridad de verdad.
  *
- * Recortar no pierde lo que sirve: para depurar un bloqueo de CSP lo que
- * importa es qué esquema se bloqueó, no qué había adentro.
+ * `blob:` está afuera a propósito aunque parezca jerárquico: su contenido es
+ * otra URL entera —`blob:https://usuario:token@sitio/x`— y esa no la ve
+ * `new URL` como autoridad suya.
  */
 const ESQUEMAS_CON_RUTA = new Set([
 	'http:',
@@ -49,12 +51,32 @@ const ESQUEMAS_CON_RUTA = new Set([
 	'wss:',
 	'ftp:',
 	'file:',
-	'blob:',
 	// Los que usa Tauri para servir la aplicación y hablar con el backend.
 	'tauri:',
 	'asset:',
 	'ipc:',
 ]);
+
+/**
+ * Si la dirección tiene autoridad, o sea si su parte después del esquema es
+ * una ruta y no una carga útil.
+ *
+ * `file:` es la excepción: sus direcciones son `file:///ruta`, sin sitio, y no
+ * pueden llevar credenciales porque la especificación no se lo permite.
+ * Recortarlas perdería la ruta, que es justo lo que sirve para depurar.
+ */
+function esJerarquica(url: URL): boolean {
+	return url.host !== '' || url.protocol === 'file:';
+}
+
+/**
+ * Si la dirección declara una autoridad, aunque no se haya podido parsear.
+ *
+ * Se usa para no caer al respaldo con algo que puede llevar credenciales.
+ * Mirar sólo si hay un `@` no serviría: una ruta relativa como
+ * `/assets/@vite/client.js` tiene uno y es de las más comunes que hay.
+ */
+const CON_AUTORIDAD = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i;
 
 /** Un esquema inventado para poder parsear una URL sin esquema propio. */
 const ESQUEMA_PRESTADO = 'https:';
@@ -91,21 +113,29 @@ export function sanearUrl(valor: string | null | undefined): string {
 	if (valor.startsWith('//')) {
 		try {
 			const url = sinCredenciales(new URL(`${ESQUEMA_PRESTADO}${valor}`));
-			return `//${url.host}${url.pathname}`;
+			// `new URL` completa una ruta ausente con «/», y eso cambia la forma
+			// de lo que llegó: `//sitio` volvía como `//sitio/`. Se devuelve
+			// como vino.
+			const sinRuta = url.pathname === '/' && !valor.split(/[?#]/)[0].endsWith('/');
+			return sinRuta ? `//${url.host}` : `//${url.host}${url.pathname}`;
 		} catch {
-			// Ni con esquema prestado: no es una URL. Cae al corte de abajo.
+			// Ni con esquema prestado. No se cae al respaldo: lo que declara una
+			// autoridad puede llevar credenciales, y el respaldo sólo corta la
+			// query y el fragmento.
+			return '';
 		}
 	}
 
 	try {
 		const url = new URL(valor);
-		if (!ESQUEMAS_CON_RUTA.has(url.protocol)) {
+		if (!ESQUEMAS_CON_RUTA.has(url.protocol) || !esJerarquica(url)) {
 			return `${url.protocol}(recortado)`;
 		}
 		return sinCredenciales(url).href;
 	} catch {
-		// Una ruta relativa. No puede llevar credenciales —eso necesita una
-		// autoridad— así que alcanza con quitarle la query y el fragmento.
-		return valor.split(/[?#]/)[0];
+		// Sin autoridad no puede haber credenciales —requieren una— así que
+		// alcanza con quitar la query y el fragmento. Con autoridad no se
+		// arriesga: si no se pudo parsear, no se registra.
+		return CON_AUTORIDAD.test(valor) ? '' : valor.split(/[?#]/)[0];
 	}
 }

--- a/tests/csp.test.ts
+++ b/tests/csp.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+import { MARCADORES_CSP, sanearUrl } from '../src/tools/csp';
+
+/**
+ * Lo que se registra al bloquearse un recurso es una URL que eligió otro, y las
+ * URL llevan credenciales. Lo que estas pruebas cuidan es que ninguna termine
+ * en el diario.
+ */
+describe('sanearUrl', () => {
+	test('una URL relativa al protocolo no deja pasar las credenciales', () => {
+		// El caso reportado: `new URL` sin base rechaza estas direcciones, y la
+		// versión anterior caía a cortar por `?` y `#`, que deja el token.
+		const limpia = sanearUrl('//user:token@example.test/path?access_token=secret#frag');
+
+		for (const secreto of ['user', 'token', 'access_token', 'secret', 'frag']) {
+			expect(limpia).not.toContain(secreto);
+		}
+		expect(limpia).toBe('//example.test/path');
+	});
+
+	test('y sin credenciales conserva el sitio y la ruta', () => {
+		expect(sanearUrl('//example.test/path')).toBe('//example.test/path');
+		expect(sanearUrl('//example.test/a/b.js?x=1')).toBe('//example.test/a/b.js');
+	});
+
+	/**
+	 * El agujero que no estaba en el reporte y se encontró midiendo.
+	 *
+	 * `new URL('user:token@sitio/x')` **no** falla: lo toma como esquema opaco
+	 * `user:`, deja `username` vacío —así que limpiarlo no hace nada— y devuelve
+	 * el token entero en `href`. O sea que también filtraba por la rama buena.
+	 */
+	test('un esquema opaco no deja pasar lo que lleva adentro', () => {
+		const limpia = sanearUrl('user:token@example.test/path');
+		expect(limpia).not.toContain('token');
+		expect(limpia).toBe('user:(recortado)');
+	});
+
+	test('las credenciales de una URL absoluta tampoco', () => {
+		const limpia = sanearUrl('https://user:token@example.test/p?x=1#f');
+		for (const secreto of ['user', 'token', 'x=1', '#f']) {
+			expect(limpia).not.toContain(secreto);
+		}
+		expect(limpia).toBe('https://example.test/p');
+	});
+
+	test('los marcadores de la especificación se dejan tal cual', () => {
+		for (const marcador of MARCADORES_CSP) {
+			expect(sanearUrl(marcador)).toBe(marcador);
+		}
+	});
+
+	/**
+	 * `data` sin dos puntos es un marcador y se conserva; `data:` con contenido
+	 * es una carga útil y se recorta. Son dos cosas distintas que se escriben
+	 * casi igual.
+	 */
+	test('una URL de datos se recorta pero se sigue sabiendo que lo era', () => {
+		expect(sanearUrl('data:text/html;base64,UEFTUw==')).toBe('data:(recortado)');
+		expect(sanearUrl('data')).toBe('data');
+	});
+
+	test('una ruta relativa pierde la query y el fragmento', () => {
+		expect(sanearUrl('/assets/app.js?v=2#top')).toBe('/assets/app.js');
+		expect(sanearUrl('app.js')).toBe('app.js');
+	});
+
+	/**
+	 * Vacío al entrar y vacío al salir son casos distintos, y quien llame tiene
+	 * que aplicar su texto de reserva **después** de sanear. Una entrada como
+	 * `?token=X` no es vacía, pero lo que queda de ella sí — y sin esto el
+	 * registro salía con el campo en blanco.
+	 */
+	test('lo que queda en nada devuelve vacío', () => {
+		expect(sanearUrl('?token=X')).toBe('');
+		expect(sanearUrl('#fragment')).toBe('');
+		expect(sanearUrl('')).toBe('');
+		expect(sanearUrl(null)).toBe('');
+		expect(sanearUrl(undefined)).toBe('');
+	});
+
+	test('nunca devuelve algo que parezca credencial', () => {
+		// Una red de seguridad sobre todos los casos de arriba juntos: si en el
+		// resultado queda un `@` antes de la primera barra, hay userinfo.
+		for (const entrada of [
+			'//u:p@sitio/x',
+			'https://u:p@sitio/x',
+			'user:p@sitio/x',
+			'ftp://u:p@sitio/x',
+		]) {
+			const limpia = sanearUrl(entrada);
+			const autoridad = limpia.replace(/^[a-z]+:/, '').replace(/^\/\//, '').split('/')[0];
+			expect(autoridad).not.toContain('@');
+		}
+	});
+});

--- a/tests/csp.test.ts
+++ b/tests/csp.test.ts
@@ -93,4 +93,62 @@ describe('sanearUrl', () => {
 			expect(autoridad).not.toContain('@');
 		}
 	});
+
+	/**
+	 * Un esquema jerárquico también admite forma opaca, y ahí las credenciales
+	 * viajan en lo que la URL llama «ruta» — donde limpiar `username` no hace
+	 * nada, porque para un esquema opaco ese campo ni existe.
+	 *
+	 * `blob:` es el caso más claro: su contenido es **otra URL entera**.
+	 */
+	test('un esquema conocido en forma opaca tampoco deja pasar nada', () => {
+		for (const entrada of [
+			'blob:https://user:token@example.test/path',
+			'tauri:user:token@example.test',
+			'asset:user:token@example.test',
+			'ipc:user:token@example.test',
+		]) {
+			expect(sanearUrl(entrada)).not.toContain('token');
+		}
+		expect(sanearUrl('blob:https://user:token@example.test/x')).toBe('blob:(recortado)');
+	});
+
+	test('y en forma jerárquica el mismo esquema sí conserva sitio y ruta', () => {
+		expect(sanearUrl('asset://user:token@example.test/path')).toBe('asset://example.test/path');
+	});
+
+	/**
+	 * `new URL` completa una ruta ausente con «/». Eso cambia la forma de lo
+	 * que llegó, y lo que se registra tiene que parecerse a lo que se bloqueó.
+	 */
+	test('una autoridad sola no gana una barra que no tenía', () => {
+		expect(sanearUrl('//example.test')).toBe('//example.test');
+		expect(sanearUrl('//example.test?x=1')).toBe('//example.test');
+		// Y la que sí la tenía la conserva.
+		expect(sanearUrl('//example.test/')).toBe('//example.test/');
+	});
+
+	/**
+	 * Si algo declara autoridad y no se pudo parsear, no se registra.
+	 *
+	 * El respaldo sólo corta la query y el fragmento, así que dejaría pasar las
+	 * credenciales enteras. Perder la línea del diario es mejor que dejar un
+	 * token escrito ahí para siempre.
+	 */
+	test('lo que declara autoridad y no parsea no se registra', () => {
+		expect(sanearUrl('//user:token@[malformado/x')).toBe('');
+		expect(sanearUrl('https://user:token@[malformado/x')).toBe('');
+	});
+
+	/**
+	 * Y la razón por la que no alcanza con rechazar todo lo que tenga un `@`:
+	 * las rutas de Vite lo llevan, y son de las más frecuentes que hay.
+	 */
+	test('una ruta relativa con arroba sobrevive', () => {
+		expect(sanearUrl('/assets/@vite/client.js')).toBe('/assets/@vite/client.js');
+		expect(sanearUrl('/node_modules/.vite/deps/@vue_devtools.js?v=1')).toBe(
+			'/node_modules/.vite/deps/@vue_devtools.js'
+		);
+	});
+
 });


### PR DESCRIPTION
## Qué pasaba

Cuando el motor bloquea un recurso por la política de contenido, se registra qué fue — porque una violación de CSP no se ve: el recurso no carga y la interfaz queda a medias sin decir nada. Pero lo que se registra es una URL que eligió otro, y las URL llevan credenciales.

Dos agujeros. Uno estaba reportado, el otro apareció midiendo:

| Entrada | Qué hacía |
|---|---|
| `//user:token@sitio/x` | `new URL` sin base falla, y el respaldo cortaba por `?` y `#` — **`user:token@` quedaba en el diario** |
| `user:token@sitio/x` | `new URL` **no** falla: lo toma como esquema opaco `user:`, deja `username` vacío —así que limpiarlo no hace nada— y devuelve el token entero en `href` |

El segundo no estaba en el reporte: filtraba por la rama buena, no por el respaldo.

## Qué hace

Las relativas al protocolo se parsean con un esquema prestado y se devuelven en la misma forma. De un esquema que **no** es jerárquico se registra sólo el esquema: para depurar un bloqueo importa qué se bloqueó, no qué había adentro.

## Y el orden del respaldo

Iba **antes** de sanear. Una entrada como `?token=X` es verdadera, así que pasaba el respaldo de largo — pero lo que queda de ella al sanearla es nada, y el registro salía con el campo en blanco.

Algunas copias llevaban un comentario afirmando lo contrario —que `sanearUrl` nunca devuelve vacío para una entrada con contenido— y era **falso**. Se reemplazó junto con el código: un comentario que justifica bien una decisión por una razón falsa es peor que ninguno.

## Por qué sale de `main.ts`

Para poder probarla: importar `main.ts` arranca la aplicación. Ahora vive en `src/tools/csp.ts`.

Nueve pruebas, **verificadas contra la versión anterior**: tres fallan con la vieja, incluida una red de seguridad que comprueba que no quede un `@` en la autoridad del resultado, sea cual sea la forma de la entrada.

## Alcance

El mismo código estaba copiado en **14 repositorios** y sólo 5 tenían issue. Arreglar cinco y dejar nueve con el mismo agujero no tenía sentido, así que va en todos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved Content Security Policy (CSP) reporting by sanitizing reported URLs before they are displayed or processed.
  * Sensitive URL details, including credentials, query parameters, and fragments, are removed from CSP violation information.
  * CSP marker values and supported URL formats continue to be handled correctly.

* **Bug Fixes**
  * CSP reports now use fallback labels only when no sanitized URL is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->