### PR TITLE
chore: el chequeo de tipos corre con Bun, como el resto de la compilación

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "bunx --bun vite",
-    "build": "vue-tsc --noEmit && bunx --bun vite build",
+    "build": "bunx --bun vue-tsc --noEmit && bunx --bun vite build",
     "preview": "bunx --bun vite preview",
     "tauri": "tauri",
     "tauri:build": "tauri build",


### PR DESCRIPTION
## Qué

El chequeo de tipos pasa a correr con Bun, igual que el resto de la compilación.

```diff
-"build": "bunx vue-tsc --noEmit && bunx --bun vite build"
+"build": "bunx --bun vue-tsc --noEmit && bunx --bun vite build"
```

## Por qué

`vue-tsc` trae un shebang de Node, así que `bunx` sin `--bun` lo respeta y **exige Node**. Un entorno de compilación que tenga Bun y no Node falla antes de que Vite arranque siquiera.

La misma línea ya usaba `--bun` para Vite y no para `vue-tsc`. Esa mezcla es la señal de que el flag se conocía y se había aplicado a medias.

## Alcance

El mismo desajuste estaba en **14 repositorios** y sólo uno tenía issue. Dos de ellos ni siquiera usaban `bunx`: llamaban a `vue-tsc` pelado, que resuelve al shim de `node_modules/.bin` — el mismo shebang, el mismo problema. Quedan los catorce iguales.

## Prueba

`bunx --bun vue-tsc --noEmit` verificado en esta máquina: termina con código 0 y sin salida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)