### PR TITLE
chore: el esquema de biome apunta a la versión instalada

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
Actualizar las dependencias trajo biome 2.5.12 y el `$schema` de
biome.json se quedó en 2.5.9. Biome informa la diferencia en cada
corrida, y el chequeo previo a empaquetar cuenta esos avisos: con uno
solo alcanza para que el paquete no se compile, así que la tanda entera
de doce se plantó sin que hubiera nada mal en el código.

Lo escribe `biome migrate`, que no toca ninguna otra línea.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the JSON configuration schema reference to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->