### PR TITLE
chore: recompilar contra config-manager 2.6.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@tauri-apps/plugin-opener": "~2.5.5",
         "@tauri-apps/plugin-shell": "~2.3.6",
         "@vasakgroup/plugin-bluetooth-manager": "^2.0.0",
-        "@vasakgroup/plugin-config-manager": "^2.5.0",
+        "@vasakgroup/plugin-config-manager": "^2.6.0",
         "@vasakgroup/plugin-network-manager": "^2.2.0",
         "@vasakgroup/plugin-user-data": "^2.0.0",
         "@vasakgroup/plugin-vicons": "^2.1.2",
@@ -255,7 +255,7 @@
 
     "@vasakgroup/plugin-bluetooth-manager": ["@vasakgroup/plugin-bluetooth-manager@2.0.0", "", { "dependencies": { "@tauri-apps/api": ">=2.0.0-beta.6" } }, "sha512-94iVctu970elX9F2fyyihjLDkaUDGkvPMqLJBa7clV3BMxQz/t5vcfBgRxiNYp8NY3vf7UCM9RGPdnxsjI9PfA=="],
 
-    "@vasakgroup/plugin-config-manager": ["@vasakgroup/plugin-config-manager@2.5.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.0", "pinia": "^3.0.4", "vue": "^3.5.35" } }, "sha512-WzAXj2j7mAsqU/690/If7P2qIpjAJtusKGMh9HMpP3JLxev80mdNtHDrRND+twZTtA670gk3v99r2AetfNCkSw=="],
+    "@vasakgroup/plugin-config-manager": ["@vasakgroup/plugin-config-manager@2.6.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.0", "pinia": "^3.0.4", "vue": "^3.5.35" } }, "sha512-whuljNNZ+bupRmX8jHe/z+8N1BQkLEuEwSsqKp7LfJ4StlgSk9rDcQnIENQ6O8QKU8RFCuf1yQ9lbG9k8ajG8A=="],
 
     "@vasakgroup/plugin-network-manager": ["@vasakgroup/plugin-network-manager@2.2.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.1" } }, "sha512-G8SWAnjbdGPoAXsjhh81YvrieLGkP1Lm8T/pZFRdD8bKb7O4SMJovyuCkT/wUrGypIg34fNnDULDFs3F6YRENQ=="],
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@tauri-apps/plugin-opener": "~2.5.5",
     "@tauri-apps/plugin-shell": "~2.3.6",
     "@vasakgroup/plugin-bluetooth-manager": "^2.0.0",
-    "@vasakgroup/plugin-config-manager": "^2.5.0",
+    "@vasakgroup/plugin-config-manager": "^2.6.0",
     "@vasakgroup/plugin-network-manager": "^2.2.0",
     "@vasakgroup/plugin-user-data": "^2.0.0",
     "@vasakgroup/plugin-vicons": "^2.1.2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1353,7 +1353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3390,7 +3390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4166,7 +4166,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4987,9 +4987,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-config-manager"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff20817a37669d89d2346de4d1c6ac3258a4d28b98924e4115cc22bd40f78b5"
+checksum = "d7ded4a825c8e819683d6f40ff22add5589881c0c4e1f2dc80c6c5798b0f987b"
 dependencies = [
  "home",
  "notify",
@@ -5296,7 +5296,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6277,7 +6277,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Sube el plugin de configuración a 2.6.0, en Rust y en JS.

Es la versión que **deja de comerse `desktop.widgets`**: hasta la 2.5.0, `read_config`
devolvía el modelo del plugin reserializado y ese modelo no conocía la clave, así que
acomodar los widgets y después cambiar cualquier cosa en Ajustes —el tema, la fuente— los
devolvía a la disposición de fábrica. A `desktop.pausevideoonbattery`, que este repositorio
lee para el fondo en video, le pasaba lo mismo: la elección no sobrevivía a la lectura
siguiente.

Trae además que elegir las fuentes en Ajustes llegue a las aplicaciones GTK y Qt.

## Comprobado

`bun run tauri build` completo en verde —`vue-tsc --noEmit`, `vite build` y el `release` de
Rust en 10m 55s— y el `Cargo.lock` y el `bun.lock` ya en 2.6.0. Nada del código de este
repositorio hizo falta cambiar: el tipo `VSKConfig` del plugin ahora declara que `desktop`
puede llevar claves de otras aplicaciones, que es de donde salían los widgets.

`bun test`: 79 de 80. El que falla —`politica-de-contenido`, «permite todos los servidores
que el código consulta»— **ya fallaba en `main`** y no tiene que ver con esto: el `https://usuario`
del comentario de [src/tools/csp.ts:44](src/tools/csp.ts#L44), que entró en #63, lo cuenta
como un servidor de verdad. Va por separado.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the configuration manager package to the latest compatible minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->