### PR TITLE
fix: la política de contenido se compara con el código, no con los comentarios

### DIFF
--- a/src/tools/politica-de-contenido.test.ts
+++ b/src/tools/politica-de-contenido.test.ts
@@ -69,9 +69,12 @@ function permitidos(): Set<string> {
  * como estado propio, y sólo fuera de ellas un `//` o un `/*` empieza un
  * comentario.
  *
- * Las de comillas simples y dobles terminan también con el fin de línea, que es
- * lo que dice la especificación: así una apóstrofe en el texto de una plantilla
- * —`don't`— no se puede comer el resto del archivo.
+ * Y una comilla simple o doble abre cadena sólo si cierra en su misma línea, que
+ * es lo único que la especificación permite. Así la apóstrofe del texto de una
+ * plantilla —`don't`— no abre nada: si abriera, el resto de la línea se
+ * copiaría tal cual, y un `<!-- … -->` que viniera después en esa línea
+ * quedaría sin filtrar. No alcanzaba con cortar la cadena en el fin de línea,
+ * porque lo copiado hasta ahí es justamente lo que había que sacar.
  *
  * Lo quitado se reemplaza por espacios y saltos en lugar de sacarse, para no
  * pegar dos trozos que estaban separados.
@@ -81,6 +84,19 @@ export function sinComentarios(fuente: string): string {
 	let i = 0;
 
 	const hueco = (c: string) => (c === '\n' ? '\n' : ' ');
+
+	/** Si hay una comilla igual —sin escapar— antes de que termine la línea. */
+	const cierraEnLaLinea = (desde: number, comilla: string) => {
+		for (let j = desde; j < fuente.length; j++) {
+			if (fuente[j] === '\\') {
+				j++;
+				continue;
+			}
+			if (fuente[j] === '\n') return false;
+			if (fuente[j] === comilla) return true;
+		}
+		return false;
+	};
 
 	while (i < fuente.length) {
 		const dos = fuente.slice(i, i + 2);
@@ -118,6 +134,19 @@ export function sinComentarios(fuente: string): string {
 		const comilla = fuente[i];
 
 		if (comilla === '"' || comilla === "'" || comilla === '`') {
+			// Sin pareja no es una cadena: es una apóstrofe del texto de una
+			// plantilla. Se copia y se sigue mirando lo que viene, que puede ser
+			// un comentario. La pareja se busca en la línea para las comillas y
+			// en el resto del archivo para las plantillas, que sí cruzan líneas.
+			const pareja =
+				comilla === '`' ? fuente.indexOf('`', i + 1) !== -1 : cierraEnLaLinea(i + 1, comilla);
+
+			if (!pareja) {
+				salida += comilla;
+				i++;
+				continue;
+			}
+
 			salida += comilla;
 			i++;
 
@@ -127,7 +156,6 @@ export function sinComentarios(fuente: string): string {
 					i += 2;
 					continue;
 				}
-				if (comilla !== '`' && fuente[i] === '\n') break;
 
 				salida += fuente[i];
 				i++;
@@ -238,6 +266,21 @@ describe('política de contenido', () => {
 		const fuente = ["<span>don't</span>", "fetch('https://api.open-meteo.com/x');"].join('\n');
 
 		expect(sinComentarios(fuente)).toContain('https://api.open-meteo.com/x');
+	});
+
+	test('una apóstrofe de texto no le abre la puerta a un comentario sin filtrar', () => {
+		// Lo que encontró la revisión de #67: en una plantilla, la apóstrofe de
+		// `don't` no tiene pareja, así que si abriera una cadena el resto de la
+		// línea se copiaría tal cual —comentario incluido— y `usuario` volvería a
+		// aparecer como servidor. Una cadena de verdad cierra en su misma línea;
+		// una apóstrofe de texto, no.
+		const fuente = "<span>don't</span> <!-- blob:https://usuario:token@sitio/x -->";
+
+		const encontrados = [
+			...sinComentarios(fuente).matchAll(/https:\/\/[a-zA-Z0-9._-]+(?::\d+)?/g),
+		].map(([origen]) => origen);
+
+		expect(encontrados).toEqual([]);
 	});
 
 	test('no permite servidores que nadie consulta', () => {

--- a/src/tools/politica-de-contenido.test.ts
+++ b/src/tools/politica-de-contenido.test.ts
@@ -52,6 +52,98 @@ function permitidos(): Set<string> {
 	);
 }
 
+/**
+ * El archivo sin sus comentarios.
+ *
+ * Un comentario no consulta nada, y contarlo como si lo hiciera es lo que dejó
+ * este test fallando en `main`: el ejemplo `blob:https://usuario:token@sitio/x`
+ * que explica por qué `blob:` queda afuera en `csp.ts` daba el «servidor»
+ * `usuario` —la parte de usuario de una URL con credenciales—, y la política
+ * lógicamente no nombra a nadie así. El problema es de la clase que vuelve:
+ * cualquier enlace a documentación en un comentario habría hecho lo mismo.
+ *
+ * No alcanza con borrar de `//` hasta el fin de la línea: el `//` de `https://`
+ * abriría un comentario en el medio de las URL de verdad y se llevaría puesto
+ * justo lo que este test busca —y el test pasaría, porque no encontrar nada no
+ * es encontrar algo que falte—. Así que se recorre el archivo con las cadenas
+ * como estado propio, y sólo fuera de ellas un `//` o un `/*` empieza un
+ * comentario.
+ *
+ * Las de comillas simples y dobles terminan también con el fin de línea, que es
+ * lo que dice la especificación: así una apóstrofe en el texto de una plantilla
+ * —`don't`— no se puede comer el resto del archivo.
+ *
+ * Lo quitado se reemplaza por espacios y saltos en lugar de sacarse, para no
+ * pegar dos trozos que estaban separados.
+ */
+export function sinComentarios(fuente: string): string {
+	let salida = '';
+	let i = 0;
+
+	const hueco = (c: string) => (c === '\n' ? '\n' : ' ');
+
+	while (i < fuente.length) {
+		const dos = fuente.slice(i, i + 2);
+
+		if (dos === '//') {
+			while (i < fuente.length && fuente[i] !== '\n') {
+				salida += ' ';
+				i++;
+			}
+			continue;
+		}
+
+		if (dos === '/*') {
+			while (i < fuente.length && fuente.slice(i, i + 2) !== '*/') {
+				salida += hueco(fuente[i]);
+				i++;
+			}
+			salida += '  ';
+			i += 2;
+			continue;
+		}
+
+		// Los de las plantillas de Vue, que también son comentarios y también
+		// pueden llevar una dirección de ejemplo.
+		if (fuente.startsWith('<!--', i)) {
+			while (i < fuente.length && !fuente.startsWith('-->', i)) {
+				salida += hueco(fuente[i]);
+				i++;
+			}
+			salida += '   ';
+			i += 3;
+			continue;
+		}
+
+		const comilla = fuente[i];
+
+		if (comilla === '"' || comilla === "'" || comilla === '`') {
+			salida += comilla;
+			i++;
+
+			while (i < fuente.length) {
+				if (fuente[i] === '\\') {
+					salida += fuente.slice(i, i + 2);
+					i += 2;
+					continue;
+				}
+				if (comilla !== '`' && fuente[i] === '\n') break;
+
+				salida += fuente[i];
+				i++;
+
+				if (fuente[i - 1] === comilla) break;
+			}
+			continue;
+		}
+
+		salida += fuente[i];
+		i++;
+	}
+
+	return salida;
+}
+
 /** Los servidores que el código nombra, con dónde los nombra. */
 function usados(): Map<string, string[]> {
 	const encontrados = new Map<string, string[]>();
@@ -68,7 +160,7 @@ function usados(): Map<string, string[]> {
 
 			// Un servidor vacío —el `https://` suelto de un comentario o de un
 			// `startsWith`— no es nadie a quien se le pida nada.
-			for (const [origen] of readFileSync(camino, 'utf8').matchAll(
+			for (const [origen] of sinComentarios(readFileSync(camino, 'utf8')).matchAll(
 				/https:\/\/[a-zA-Z0-9._-]+(?::\d+)?/g
 			)) {
 				const servidor = normalizarOrigen(origen);
@@ -97,6 +189,55 @@ describe('política de contenido', () => {
 		expect(normalizarOrigen('https://donde:443')).toBe(normalizarOrigen('https://donde'));
 		// Y uno distinto sí, porque la política tampoco lo da por permitido.
 		expect(normalizarOrigen('https://donde:8443')).not.toBe(normalizarOrigen('https://donde'));
+	});
+
+	test('los servidores que el código sí consulta se encuentran', () => {
+		// El guardia del arreglo: quitar comentarios de más dejaría este test sin
+		// nada que comparar, y sin nada que comparar nunca falta nada. Los dos
+		// del clima están en plantillas de `useWeather`, o sea en código.
+		const lista = usados();
+
+		expect([...lista.keys()].sort()).toEqual([
+			'api.open-meteo.com',
+			'geocoding-api.open-meteo.com',
+		]);
+	});
+
+	test('una dirección en un comentario no es un servidor que se consulte', () => {
+		// El caso que dejó el test fallando: el ejemplo de `csp.ts`, que ni es una
+		// dirección a la que se le pida algo ni tiene un servidor llamado
+		// «usuario» —eso es la parte de usuario de una URL con credenciales—.
+		const fuente = [
+			'/**',
+			' * `blob:https://usuario:token@sitio/x`',
+			' */',
+			"const url = 'https://api.open-meteo.com/v1/forecast';",
+			'// https://developer.mozilla.org/docs',
+		].join('\n');
+
+		const encontrados = [
+			...sinComentarios(fuente).matchAll(/https:\/\/[a-zA-Z0-9._-]+(?::\d+)?/g),
+		].map(([origen]) => origen);
+
+		expect(encontrados).toEqual(['https://api.open-meteo.com']);
+	});
+
+	test('el `//` de una dirección no abre un comentario', () => {
+		// Lo que rompe la versión ingenua: borrar de `//` al fin de línea se lleva
+		// la dirección de verdad, el test se queda sin nada y pasa igual.
+		const fuente = "fetch('https://api.open-meteo.com/v1/forecast'); // el clima";
+
+		expect(sinComentarios(fuente)).toContain('https://api.open-meteo.com/v1/forecast');
+		expect(sinComentarios(fuente)).not.toContain('el clima');
+	});
+
+	test('una apóstrofe en una plantilla no se come el resto del archivo', () => {
+		// Las cadenas de comillas simples y dobles terminan con la línea, como
+		// dice la especificación. Si no, el `'` de `don't` abriría una cadena que
+		// seguiría hasta la próxima comilla del archivo y escondería lo de abajo.
+		const fuente = ["<span>don't</span>", "fetch('https://api.open-meteo.com/x');"].join('\n');
+
+		expect(sinComentarios(fuente)).toContain('https://api.open-meteo.com/x');
 	});
 
 	test('no permite servidores que nadie consulta', () => {


### PR DESCRIPTION
El test que compara `connect-src` con los servidores que el código consulta **fallaba en
`main`** (79 de 80 en `bun test`), desde el PR #63:

```
+ [ "usuario (en src/tools/csp.ts)" ]
```

Contaba el ejemplo `blob:https://usuario:token@sitio/x` del comentario de
[csp.ts:44](src/tools/csp.ts#L44) —el que explica por qué `blob:` queda afuera de los
esquemas con ruta— y de ahí sacaba el «servidor» `usuario`, que no es un servidor: es la
parte de usuario de una URL con credenciales. La política, lógicamente, no nombra a nadie
así.

Y es de la clase de fallo que vuelve: cualquier enlace a documentación en un comentario
habría hecho lo mismo.

## El arreglo

Las direcciones se buscan en el archivo **sin comentarios**. Lo interesante es por qué no
alcanza con borrar de `//` hasta el fin de la línea: el `//` de `https://` abriría un
comentario en el medio de las URL de verdad y se llevaría puesto justo lo que el test busca
—y el test **pasaría**, porque no encontrar nada no es encontrar algo que falte—. Así que se
recorre el archivo con las cadenas como estado propio:

- las de comillas simples y dobles terminan también con el fin de línea, como dice la
  especificación, así una apóstrofe en el texto de una plantilla (`don't`) no se puede comer
  el resto del archivo;
- las plantillas (`` ` ``) sí cruzan líneas, que es donde están las dos URL del clima;
- los `<!-- -->` de las plantillas de Vue se tratan como los comentarios que son.

## Comprobado

`bun test`: **84 de 84**, con 5 tests nuevos. Uno es el guardia del arreglo —los dos
servidores del clima tienen que seguir encontrándose—, porque un limpiador demasiado
entusiasta dejaría la comparación sin nada que comparar y el test verde por vacío. Los otros
cubren el caso que fallaba, el `//` que no abre comentario y la apóstrofe.

`biome check` y `vue-tsc --noEmit` limpios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved source analysis so URLs inside JavaScript, TypeScript, Vue, HTML, and block comments are ignored.
  - Prevented comment content from being mistaken for queried servers.
  - Preserved valid URLs in strings, template content, and escaped characters.
  - Maintained source line structure during comment handling.

- **Tests**
  - Added coverage for real server detection, commented URLs, protocol-style `//` text, and apostrophes in template content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->