### PR TITLE
ci: llamar a los chequeos compartidos de la organización

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+# Los chequeos viven en el repositorio `.github` de la organización, así que
+# acá sólo se los llama. Cambiarlos es cambiarlos en un solo lugar.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  app:
+    uses: Vasak-OS/.github/.github/workflows/app.yml@main


### PR DESCRIPTION
Hasta ahora no había ninguna comprobación automática en este repositorio:
todo se revisaba a mano en la máquina de quien iba a compilar, justo
antes de compilar, así que un problema aparecía con la tanda ya empezada.

Los chequeos —versión coherente entre los manifiestos, biome, `vue-tsc` y
el candado de Cargo al día— están en `Vasak-OS/.github`. Acá van cinco
líneas que los llaman: son treinta y pico de repositorios y un chequeo
copiado treinta veces es un chequeo que en algunos queda viejo.

Son los cuatro que efectivamente mordieron. El de la versión, porque un
paquete cuyo número no subió no se recompila y lo mergeado no llega a
nadie. El del candado, porque `makepkg` compila con `--locked` y a mano
no se nota nunca.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated continuous integration checks for updates submitted to the main code line and pull requests.
  * This helps ensure changes are validated consistently before they are merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->