### PR TITLE
ci: el llamado pide sólo lectura

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,4 +9,13 @@ on:
 
 jobs:
   app:
+    # Sólo lectura. Estos chequeos clonan, instalan dependencias y comprueban:
+    # no comentan, no etiquetan, no publican.
+    #
+    # El workflow llamado declara lo mismo en su trabajo, que es donde el
+    # permiso se aplica; esto lo escribe también acá porque el análisis
+    # estático de este repositorio no puede ver el otro archivo, y ahí un
+    # trabajo sin `permissions` se lee como permisos por omisión.
+    permissions:
+      contents: read
     uses: Vasak-OS/.github/.github/workflows/app.yml@main


### PR DESCRIPTION
Estos chequeos clonan, instalan dependencias y comprueban: no comentan, no
etiquetan, no publican nada. Sin declararlo, el trabajo recibe los
permisos por omisión del repositorio, que en los más viejos incluyen
escritura sobre casi todo, y ese token queda a mano de cualquier paso.

El workflow reusable ya declara lo mismo en su trabajo, que es donde el
permiso de verdad se aplica; esto lo escribe también en el llamador porque
el análisis estático de cada repositorio no puede ver el otro archivo, y
ahí un trabajo sin `permissions` se lee como permisos por omisión. Lo
señalaron tres revisiones seguidas, una por cada PR que tocó un llamador.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration permissions to explicitly allow read-only repository access.
  * Added documentation clarifying the checks’ read-only behavior and permission configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->