### PR TITLE
La ventana abre con los textos puestos

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@vasakgroup/plugin-vicons": "^2.1.2",
         "@vasakgroup/plugin-vsk-contextual-menu": "2.0.2",
         "@vasakgroup/plugin-vsk-journal": "^2.0.0",
-        "@vasakgroup/tauri-plugin-i18n": "^2.1.0",
+        "@vasakgroup/tauri-plugin-i18n": "^2.3.0",
         "@vasakgroup/vue-libvasak": "~0.2.3",
         "pinia": "^3.0.4",
         "vue": "^3.5.42",
@@ -267,7 +267,7 @@
 
     "@vasakgroup/plugin-vsk-journal": ["@vasakgroup/plugin-vsk-journal@2.0.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-UsFkQFym0kgM7aOIsrrtsE1F/XU6u0QkFRLYiVBWTCsMdDobn1BE+ca/Ym06l3tHqohNwDO8VbtGySlOAHPq1g=="],
 
-    "@vasakgroup/tauri-plugin-i18n": ["@vasakgroup/tauri-plugin-i18n@2.1.0", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" }, "peerDependencies": { "vue": "^3.0.0" }, "optionalPeers": ["vue"] }, "sha512-zeM7pJc5b4BERCvkbrBQhvmqxLmlzqmIAkCIdJNIioS5uZwbvZsGDcgC6XqFn22TvNsj0zceTf55PM2byEUNsg=="],
+    "@vasakgroup/tauri-plugin-i18n": ["@vasakgroup/tauri-plugin-i18n@2.3.0", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" }, "peerDependencies": { "vue": "^3.0.0" }, "optionalPeers": ["vue"] }, "sha512-koBn+sk2OECl8g37N4CyjkDSBTrH0ZXERic9jfAz9qKE9UD3cgyx5Lh5P71VX/Z6DPeAhdl0UGGY5cS8e+mkww=="],
 
     "@vasakgroup/vue-libvasak": ["@vasakgroup/vue-libvasak@0.2.3", "", { "dependencies": { "@tauri-apps/api": "^2.10.1", "@vasakgroup/plugin-vicons": "^2.0.0", "vue": "^3.5.28", "vue-router": "^5.0.3" } }, "sha512-amkGEPH1Zc5Gs8XOufK6DlcRmFuxkXealQkSas1kG48ODAwWnSAlJ2h9ltdok/Ov7Qflonkod93rw3J+kThVtw=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@vasakgroup/plugin-vicons": "^2.1.2",
     "@vasakgroup/plugin-vsk-contextual-menu": "2.0.2",
     "@vasakgroup/plugin-vsk-journal": "^2.0.0",
-    "@vasakgroup/tauri-plugin-i18n": "^2.1.0",
+    "@vasakgroup/tauri-plugin-i18n": "^2.3.0",
     "@vasakgroup/vue-libvasak": "~0.2.3",
     "pinia": "^3.0.4",
     "vue": "^3.5.42",

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,15 @@ import { sanearUrl } from '@/tools/csp';
 import '@/assets/main.css';
 import { captureFailures } from '@vasakgroup/plugin-vsk-journal';
 
+/**
+ * Cuánto se espera a las traducciones antes de montar.
+ *
+ * Se espera para que la primera pantalla no muestre las claves crudas, pero con
+ * un plazo: si el backend no contesta, es mejor una interfaz con las claves a la
+ * vista que una ventana en blanco para siempre.
+ */
+const PLAZO_TRADUCCIONES_MS = 3000;
+
 // Una violación de CSP no se ve: el recurso no carga y la interfaz queda a
 // medias sin decir nada. Se sanean **las dos** URLs, porque `sourceFile` también
 // puede llevar query con datos sensibles.
@@ -43,8 +52,21 @@ captureFailures();
 
 const app = createApp(App);
 
-i18n.load();
 app.use(pinia);
 app.use(router);
+
+// Se esperan las traducciones antes de montar: montando primero, la ventana
+// enseña las claves crudas —«views.home.title» donde va el texto— hasta que el
+// catálogo termina de cargar.
+//
+// Antes esto era un `i18n.load()` suelto, sin esperar. Y hasta la 2.3.0 del
+// plugin esperarlo tampoco habría servido: la clase y el composable guardaban el
+// catálogo por separado, y el `t()` de los componentes lee el del composable.
+await Promise.race([
+	i18n.load().catch((error) => {
+		console.error('No se pudieron cargar las traducciones', error);
+	}),
+	new Promise((resolve) => setTimeout(resolve, PLAZO_TRADUCCIONES_MS)),
+]);
 
 app.mount('#app');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,12 @@ export default defineConfig({
 
 	// Optimización de build
 	build: {
-		target: 'es2020',
+		// es2022 y no es2020 por el `await` de nivel superior de `main.ts`, que se
+		// usa para tener las traducciones antes de montar: con es2020 esbuild lo
+		// rechaza. Es la única aplicación del escritorio con un target explícito
+		// —las demás usan el de Vite, que ya lo admite— y el WebView es el mismo
+		// en todas, así que no hay nada nuevo que pueda no entenderlo.
+		target: 'es2022',
 		minify: 'terser',
 		terserOptions: {
 			compress: {


### PR DESCRIPTION
Sube `@vasakgroup/tauri-plugin-i18n` a la **2.3.0**, que arregla el destello de
las claves de traducción al arrancar.

## Por qué es un piso de versión y no una puesta al día

Hasta la 2.1.0 el plugin guardaba el catálogo **dos veces**: en un campo de la
clase `I18n` y en unas referencias de módulo del composable `useI18n()`. El `t()`
de los componentes lee el del composable, y cargar la clase no lo tocaba.

O sea que esperar a `load()` antes de montar —que es lo que hay que hacer, y lo
que se hacía— no adelantaba nada: la ventana se montaba con el composable vacío,
su `t()` devolvía la clave tal cual, y los textos aparecían recién cuando el
`onMounted` del primer componente volvía a cargar todo por su cuenta.

La 2.3.0 tiene un solo estado, así que la espera por fin hace lo que dice. Con la
2.1.0 esta aplicación se monta con las claves a la vista, y por eso el
`package.json` pide `^2.3.0`.

De yapa, la 2.3.0 deja de cargar el catálogo **una vez por componente**: cada
`useI18n()` lo pedía en su `onMounted`, todos veían el estado vacío en el mismo
instante y ninguno se enteraba de los demás, cada uno con dos llamadas al backend
y un `listen` que no se cancelaba nunca.

## Probado

`bun test`, `vue-tsc --noEmit`, `biome check` y `bun run build` en verde. Y el
conjunto se probó abriendo una de las aplicaciones compilada: la ventana aparece
con los rótulos puestos, sin el paso por las claves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Translation resources now finish loading before the application starts, helping ensure localized content appears consistently.
  - The app continues starting if translation loading takes too long or encounters an error, preventing indefinite startup delays.
  - Core app services are initialized earlier during startup for a smoother launch experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->