### PR TITLE
El crate de traducciones, a la 2.3.0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1353,7 +1353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3390,7 +3390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4166,7 +4166,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5028,9 +5028,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-i18n-vsk"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbe2ac7b986d984ab2d9ffb02a4265e796fcde7189bcce75b15f48e2a7620c4"
+checksum = "c274f12937497ff27aef1136b8b4a420e4c40066fad4c9f01575a0cd801ee1bb"
 dependencies = [
  "globwalk",
  "normpath",
@@ -5296,7 +5296,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6277,7 +6277,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ gtk-layer-shell = { version = "0.8", features = ["v0_6"] }
 base64 = "0.22"
 #tauri-plugin-vicons = {path = "../../tauri-plugin-vicons"}
 tauri-plugin-vicons = "2"
-tauri-plugin-i18n-vsk = "2.1.1"
+tauri-plugin-i18n-vsk = "2.3.0"
 #tauri-plugin-config-manager = {path = "../../tauri-plugin-config-manager"}
 tauri-plugin-config-manager = "2"
 tauri-plugin-user-data = "2"


### PR DESCRIPTION
Sube `tauri-plugin-i18n-vsk` de **2.1.1** a **2.3.0**. Estaba dos versiones
atrás, así que se perdía los dos arreglos de la 2.2.0.

## Qué trae

**Un catálogo roto ya no impide abrir la aplicación.** El plugin entraba en
pánico por seis motivos distintos al leer los archivos de idioma —el patrón de
búsqueda, un nombre sin punto, la extensión ausente, el archivo ilegible, el
contenido que no es UTF-8, el catálogo mal formado— y cualquiera de ellos dejaba
la pantalla negra, sin ventana y sin explicación. Un catálogo roto tiene que
degradar los textos, no impedir usar el programa.

**Una aplicación instalada deja de leer catálogos del directorio actual.** Un
proceso hereda el directorio de trabajo de quien lo lanzó, y el escritorio abre
las aplicaciones desde el suyo: con el escritorio arrancado a mano desde el árbol
de fuentes de otra aplicación Tauri —cosa que se hace todo el tiempo para
probar— toda aplicación abierta desde el menú encontraba los catálogos de ésa
antes que los propios, no reconocía ninguna clave y mostraba la interfaz en
crudo. Para un binario bajo `/usr`, `/opt` o `/snap` esas rutas dejan de
consultarse; el caso de desarrollo queda igual.

## Qué cambia acá

Nada de código: `Cargo.toml` y el candado. No hay cambios de API — comprobado
compilando.

## Ojo con el segundo arreglo

Esta aplicación le pasa al plugin una ruta explícita desde su propio
`src-tauri/src/locales.rs`, así que **no** usa la búsqueda del plugin y el
arreglo de las rutas relativas no la alcanza. Peor: ese ayudante propio tiene el
mismo orden defectuoso que el plugin acaba de corregir —`locales` y
`src-tauri/locales` antes que `/usr/share/<paquete>/locales`, sin mirar si el
binario está instalado—. Va aparte, porque es código de la aplicación y no del
plugin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the internationalization support to a newer version, improving compatibility and ensuring access to the latest available fixes and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->