### PR TITLE
chore: version 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vasak-desktop",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "engines": {
     "bun": ">=1.2.21"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5882,7 +5882,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vasak-desktop"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vasak-desktop"
-version = "1.4.1"
+version = "1.4.2"
 description = "A Vasak Application (template)"
 authors = ["Vasak Group", "Joaquin (Pato) Decima"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vasak-desktop",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "ar.net.vasak.vasak-desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Lo que ya está en `main` y no llega a ninguna máquina:

- El catálogo de traducciones a **2.3.0**.
- La ventana abre con los textos puestos, en vez de mostrar las claves crudas un instante.

Patch: son arreglos y puesta al día de dependencias, sin funciones nuevas.

## Por qué hacía falta tocar la versión

`build-all.sh` decide qué compilar comparando el `pkgver` del PKGBUILD con lo
publicado, **no los commits**. Con la versión quieta el paquete se saltea para
siempre: por eso esto quedó mergeado y sin empaquetar.

## Los cuatro manifiestos

`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` y
**`src-tauri/Cargo.lock`**. El último es el que se olvida —registra la versión
del propio paquete— y no es cosmético: `makepkg` compila con `--locked`, así que
un lock desfasado corta la compilación con la tanda ya empezada. Se editó sólo
la entrada de este paquete, no un reemplazo global del número.

`check-all.sh -a vasak-desktop -D <este árbol>` → **Todas las apps compilan**.

## Después de mergear

El `pkgver` del PKGBUILD sigue en la versión vieja y hay que subirlo, o la tanda
va a seguir salteando el paquete. Va directo a `main` de `PKGBUILDS`, sin PR, y
**después** de este merge: `package()` compara su `pkgver` contra el
`tauri.conf.json` que baja de la rama publicada.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 1.4.2 across release and packaging metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->